### PR TITLE
Improvements after feedback

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,10 @@ repos:
   hooks:
     - id: makefile-doc
       files: Makefile
+- repo: local
+  hooks:
+    - id: usage-to-readme
+      name: Extract Usage Pages
+      entry: ./scripts/update_readme.sh
+      language: script
+      files: bundleutilspkg/.*\.py$

--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ Usage: bundleutils ci-setup [OPTIONS]
   Download CloudBees WAR file, and setup the starter bundle.
 
   Env vars:
-      BUNDLEUTILS_CB_DOCKER_IMAGE_{CI_TYPE}: Docker image to use for the specified CI type
-      BUNDLEUTILS_CB_WAR_DOWNLOAD_URL_{CI_TYPE}: WAR download URL to use for the specified CI type
+      BUNDLEUTILS_CB_DOCKER_IMAGE_{CI_TYPE}: Docker image for the CI_TYPE (MM, OC)
+      BUNDLEUTILS_CB_WAR_DOWNLOAD_URL_{CI_TYPE}: WAR download URL for the CI_TYPE (CM, OC_TRADITIONAL)
       BUNDLEUTILS_SKOPEO_COPY_OPTS: options to pass to skopeo copy command
 
 Options:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,349 @@ Runtime variants explained here include:
 
 For a summary of commands, see [explaining the main commands](./docs/explaining-commands.md)
 
+Help Pages
+
+<!-- START help-pages-doc -->
+```mono
+Usage: bundleutils [OPTIONS] COMMAND [ARGS]...
+
+  A tool to fetch and transform YAML documents.
+
+Options:
+  -i, --interactive     Run in interactive mode.
+  -e, --env-file FILE   Optional bundle profiles file (or use
+                        BUNDLEUTILS_ENV).
+  -l, --log-level TEXT  The log level (or use BUNDLEUTILS_LOG_LEVEL).
+  --help                Show this message and exit.
+
+Commands:
+  audit                  Transform using the normalize.yaml but...
+  bootstrap              Bootstrap a bundle
+  ci-sanitize-plugins    Sanitizes plugins (needs ci-start).
+  ci-setup               Download CloudBees WAR file, and setup the...
+  ci-start               Start CloudBees Server
+  ci-stop                Stop CloudBees Server
+  ci-validate            Validate bundle against controller started with...
+  completion             Print the shell completion script
+  config                 List evaluated config based on cwd and env file.
+  diff                   Diff two YAML directories or files.
+  extract-name-from-url  Smart extraction of the controller name from the...
+  fetch                  Fetch YAML documents from a URL or path.
+  find-bundle-by-url     Find a bundle by Jenkins URL and CI Version.
+  help-pages             Show all help pages by running 'bundleutils...
+  normalize              Transform using the normalize.yaml for better...
+  transform              Transform using a custom transformation config.
+  update-bundle          Update the bundle.yaml file in the target...
+  update-plugins         Update plugins in the target directory.
+  validate               Validate bundle in source dir against URL.
+  version                Show the app version.
+--------------------------------------------------------------------------------
+Usage: bundleutils audit [OPTIONS]
+
+  Transform using the normalize.yaml but obfuscating any sensitive data.
+
+  NOTE: The credentials and sensitive data will be hashed and cannot be used
+  in an actual bundle.
+
+Options:
+  -t, --target-dir DIRECTORY  The target directory for the YAML documents.
+                              Defaults to the source directory suffixed with
+                              -transformed.
+  -s, --source-dir DIRECTORY  The source directory for the YAML documents.
+  -c, --config TEXT           The transformation config(s).
+  -S, --strict                Fail when referencing non-existent files - warn
+                              otherwise.
+  -H, --hash-seed TEXT        Optional prefix for the hashing process (also
+                              BUNDLEUTILS_CREDENTIAL_HASH_SEED).
+                              
+                              NOTE: Ideally, this should be a secret value
+                              that is not shared with anyone. Changing this
+                              value will result in different hashes.
+  --help                      Show this message and exit.
+--------------------------------------------------------------------------------
+Usage: bundleutils bootstrap [OPTIONS]
+
+  Bootstrap a bundle
+
+Options:
+  -s, --source-dir DIRECTORY   The bundle to be bootstrapped.
+  -S, --source-base DIRECTORY  Specify parent dir of source-dir, bundle name
+                               taken from URL.
+  -p, --profile TEXT           The bundle profile to use.
+  -u, --update TEXT            Should the bundle be updated if present.
+  -U, --url TEXT               The controller URL to bootstrap (or use
+                               JENKINS_URL).
+  -v, --ci-version TEXT        Optional version (taken from the remote
+                               instance otherwise).
+  --help                       Show this message and exit.
+--------------------------------------------------------------------------------
+Usage: bundleutils ci-sanitize-plugins [OPTIONS]
+
+  Sanitizes plugins (needs ci-start).
+
+Options:
+  -H, --ci-server-home TEXT   Defaults to
+                              /tmp/ci_server_home/<ci_type>/<ci_version>.
+  -t, --ci-type TEXT          The type of the CloudBees server.
+  -v, --ci-version TEXT       The version of the CloudBees WAR file.
+  -s, --source-dir DIRECTORY  The bundle of the plugins to be sanitized.
+  -p, --pin-plugins           Add versions to 3rd party plugins (only
+                              available for apiVersion 2).
+  -c, --custom-url TEXT       Add a custom URL, e.g. http://plugins-
+                              repo/plugins/PNAME/PVERSION/PNAME.hpi
+  --help                      Show this message and exit.
+--------------------------------------------------------------------------------
+Usage: bundleutils ci-setup [OPTIONS]
+
+  Download CloudBees WAR file, and setup the starter bundle. Env vars:
+  BUNDLEUTILS_CB_DOCKER_IMAGE_{CI_TYPE}: Docker image to use for the specified
+  CI type     BUNDLEUTILS_CB_WAR_DOWNLOAD_URL_{CI_TYPE}: WAR download URL to
+  use for the specified CI type     BUNDLEUTILS_SKOPEO_COPY_OPTS: options to
+  pass to skopeo copy command
+
+Options:
+  -H, --ci-server-home TEXT       Defaults to
+                                  /tmp/ci_server_home/<ci_type>/<ci_version>.
+  -t, --ci-type TEXT              The type of the CloudBees server.
+  -v, --ci-version TEXT           The version of the CloudBees WAR file.
+  -s, --source-dir DIRECTORY      The bundle to be validated (startup will use
+                                  the plugins from here).
+  -T, --ci-bundle-template DIRECTORY
+                                  Path to a template bundle used to start the
+                                  test server (defaults to in-built tempalte).
+  --help                          Show this message and exit.
+--------------------------------------------------------------------------------
+Usage: bundleutils ci-start [OPTIONS]
+
+  Start CloudBees Server
+
+Options:
+  -H, --ci-server-home TEXT  Defaults to
+                             /tmp/ci_server_home/<ci_type>/<ci_version>.
+  -t, --ci-type TEXT         The type of the CloudBees server.
+  -v, --ci-version TEXT      The version of the CloudBees WAR file.
+  --help                     Show this message and exit.
+--------------------------------------------------------------------------------
+Usage: bundleutils ci-stop [OPTIONS]
+
+  Stop CloudBees Server
+
+Options:
+  -H, --ci-server-home TEXT  Defaults to
+                             /tmp/ci_server_home/<ci_type>/<ci_version>.
+  -t, --ci-type TEXT         The type of the CloudBees server.
+  -v, --ci-version TEXT      The version of the CloudBees WAR file.
+  --help                     Show this message and exit.
+--------------------------------------------------------------------------------
+Usage: bundleutils ci-validate [OPTIONS]
+
+  Validate bundle against controller started with ci-start.
+
+Options:
+  -H, --ci-server-home TEXT   Defaults to
+                              /tmp/ci_server_home/<ci_type>/<ci_version>.
+  -t, --ci-type TEXT          The type of the CloudBees server.
+  -v, --ci-version TEXT       The version of the CloudBees WAR file.
+  -s, --source-dir DIRECTORY  The bundle to be validated.
+  -w, --ignore-warnings       Do not fail if warnings are found.
+  --help                      Show this message and exit.
+--------------------------------------------------------------------------------
+Usage: bundleutils completion [OPTIONS]
+
+  Print the shell completion script
+
+Options:
+  -s, --shell [bash|fish|zsh]  The shell to generate completion script for.
+                               [required]
+  --help                       Show this message and exit.
+--------------------------------------------------------------------------------
+Usage: bundleutils config [OPTIONS]
+
+  List evaluated config based on cwd and env file.
+
+Options:
+  --help  Show this message and exit.
+--------------------------------------------------------------------------------
+Usage: bundleutils diff [OPTIONS] SRC1 SRC2
+
+  Diff two YAML directories or files.
+
+Options:
+  --help  Show this message and exit.
+--------------------------------------------------------------------------------
+Usage: bundleutils extract-name-from-url [OPTIONS]
+
+  Smart extraction of the controller name from the URL. Extracts NAME from the
+  following URL formats: - http://a.b.c/NAME/ - http://a.b.c/NAME -
+  https://a.b.c/NAME/ - https://a.b.c/NAME - http://NAME.b.c/ -
+  http://NAME.b.c - https://NAME.b.c/ - https://NAME.b.c
+
+Options:
+  -u, --url TEXT  The URL to extract the controller name from.
+  --help          Show this message and exit.
+--------------------------------------------------------------------------------
+Usage: bundleutils fetch [OPTIONS]
+
+  Fetch YAML documents from a URL or path.
+
+Options:
+  -t, --target-dir DIRECTORY      The target directory for the YAML documents
+                                  (or use BUNDLEUTILS_FETCH_TARGET_DIR).
+  -p, --password TEXT             Password for basic authentication (or use
+                                  BUNDLEUTILS_PASSWORD).
+  -u, --username TEXT             Username for basic authentication (or use
+                                  BUNDLEUTILS_USERNAME).
+  -U, --url TEXT                  The URL to fetch YAML from (or use
+                                  BUNDLEUTILS_JENKINS_URL).
+  -C, --catalog-warnings-strategy TEXT
+                                  Strategy for handling beekeeper warnings in
+                                  the plugin catalog (or use
+                                  BUNDLEUTILS_CATALOG_WARNINGS_STRATEGY).
+  -J, --plugins-json-merge-strategy TEXT
+                                  Strategy for merging plugins from list into
+                                  the bundle (or use
+                                  BUNDLEUTILS_PLUGINS_JSON_MERGE_STRATEGY).
+  -j, --plugins-json-list-strategy TEXT
+                                  Strategy for creating list from the plugins
+                                  json (or use
+                                  BUNDLEUTILS_PLUGINS_JSON_LIST_STRATEGY).
+  -O, --offline                   Save the export and plugin data to <target-
+                                  dir>-offline (or use
+                                  BUNDLEUTILS_FETCH_OFFLINE).
+  -c, --cap                       Use the envelope.json from the war file to
+                                  remove CAP plugin dependencies (or use
+                                  BUNDLEUTILS_FETCH_USE_CAP_ENVELOPE).
+  -P, --path FILE                 The path to fetch YAML from (or use
+                                  BUNDLEUTILS_PATH).
+  -M, --plugin-json-path TEXT     The path to fetch JSON file from (found at /
+                                  manage/pluginManager/api/json?pretty&depth=1
+                                  &tree=plugins[*[*]]).
+  --help                          Show this message and exit.
+--------------------------------------------------------------------------------
+Usage: bundleutils find-bundle-by-url [OPTIONS]
+
+  Find a bundle by Jenkins URL and CI Version.
+
+Options:
+  -U, --url TEXT               The controller URL to test for (or use
+                               JENKINS_URL).
+  -v, --ci-version TEXT        Optional version (taken from the remote
+                               instance otherwise).
+  -b, --bundles-dir DIRECTORY  The directory containing the bundles.
+  --help                       Show this message and exit.
+--------------------------------------------------------------------------------
+Usage: bundleutils help-pages [OPTIONS]
+
+  Show all help pages by running 'bundleutils --help' at the global level and
+  then per sub command.
+
+Options:
+  --help  Show this message and exit.
+--------------------------------------------------------------------------------
+Usage: bundleutils normalize [OPTIONS]
+
+  Transform using the normalize.yaml for better comparison.
+
+Options:
+  -t, --target-dir DIRECTORY  The target directory for the YAML documents.
+                              Defaults to the source directory suffixed with
+                              -transformed.
+  -s, --source-dir DIRECTORY  The source directory for the YAML documents.
+  -c, --config TEXT           The transformation config(s).
+  -S, --strict                Fail when referencing non-existent files - warn
+                              otherwise.
+  --help                      Show this message and exit.
+--------------------------------------------------------------------------------
+Usage: bundleutils transform [OPTIONS]
+
+  Transform using a custom transformation config.
+
+Options:
+  -t, --target-dir DIRECTORY  The target directory for the YAML documents.
+                              Defaults to the source directory suffixed with
+                              -transformed.
+  -s, --source-dir DIRECTORY  The source directory for the YAML documents.
+  -c, --config TEXT           The transformation config(s).
+  -S, --strict                Fail when referencing non-existent files - warn
+                              otherwise.
+  --help                      Show this message and exit.
+--------------------------------------------------------------------------------
+Usage: bundleutils update-bundle [OPTIONS]
+
+  Update the bundle.yaml file in the target directory.
+
+Options:
+  -t, --target-dir DIRECTORY  The target directory to update the bundle.yaml
+                              file.  [required]
+  -d, --description TEXT      Optional description for the bundle (also
+                              BUNDLEUTILS_BUNDLE_DESCRIPTION).
+  --help                      Show this message and exit.
+--------------------------------------------------------------------------------
+Usage: bundleutils update-plugins [OPTIONS]
+
+  Update plugins in the target directory.
+
+Options:
+  -t, --target-dir DIRECTORY      The target directory for the YAML documents
+                                  (or use BUNDLEUTILS_FETCH_TARGET_DIR).
+  -p, --password TEXT             Password for basic authentication (or use
+                                  BUNDLEUTILS_PASSWORD).
+  -u, --username TEXT             Username for basic authentication (or use
+                                  BUNDLEUTILS_USERNAME).
+  -U, --url TEXT                  The URL to fetch YAML from (or use
+                                  BUNDLEUTILS_JENKINS_URL).
+  -C, --catalog-warnings-strategy TEXT
+                                  Strategy for handling beekeeper warnings in
+                                  the plugin catalog (or use
+                                  BUNDLEUTILS_CATALOG_WARNINGS_STRATEGY).
+  -J, --plugins-json-merge-strategy TEXT
+                                  Strategy for merging plugins from list into
+                                  the bundle (or use
+                                  BUNDLEUTILS_PLUGINS_JSON_MERGE_STRATEGY).
+  -j, --plugins-json-list-strategy TEXT
+                                  Strategy for creating list from the plugins
+                                  json (or use
+                                  BUNDLEUTILS_PLUGINS_JSON_LIST_STRATEGY).
+  -O, --offline                   Save the export and plugin data to <target-
+                                  dir>-offline (or use
+                                  BUNDLEUTILS_FETCH_OFFLINE).
+  -c, --cap                       Use the envelope.json from the war file to
+                                  remove CAP plugin dependencies (or use
+                                  BUNDLEUTILS_FETCH_USE_CAP_ENVELOPE).
+  -P, --path FILE                 The path to fetch YAML from (or use
+                                  BUNDLEUTILS_PATH).
+  -M, --plugin-json-path TEXT     The path to fetch JSON file from (found at /
+                                  manage/pluginManager/api/json?pretty&depth=1
+                                  &tree=plugins[*[*]]).
+  --help                          Show this message and exit.
+--------------------------------------------------------------------------------
+Usage: bundleutils validate [OPTIONS]
+
+  Validate bundle in source dir against URL.
+
+Options:
+  -U, --url TEXT              The controller URL to validate agianst (or use
+                              BUNDLEUTILS_JENKINS_URL).
+  -u, --username TEXT         Username for basic authentication (or use
+                              BUNDLEUTILS_USERNAME).
+  -p, --password TEXT         Password for basic authentication (or use
+                              BUNDLEUTILS_PASSWORD).
+  -s, --source-dir DIRECTORY  The source directory for the YAML documents (or
+                              use BUNDLEUTILS_VALIDATE_SOURCE_DIR).
+                              [required]
+  -w, --ignore-warnings       Do not fail if warnings are found.
+  --help                      Show this message and exit.
+--------------------------------------------------------------------------------
+Usage: bundleutils version [OPTIONS]
+
+  Show the app version.
+
+Options:
+  --help  Show this message and exit.
+```
+<!-- END help-pages-doc -->
+
+
 ## Local Development
 
 To run locally:

--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ Options:
   -v, --ci-version TEXT       The version of the CloudBees WAR file.
   -s, --source-dir DIRECTORY  The bundle to be validated.
   -w, --ignore-warnings       Do not fail if warnings are found.
+  -r, --external-rbac FILE    Path to an external rbac.yaml from an Operations
+                              Center bundle.
   --help                      Show this message and exit.
 ------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils completion [OPTIONS]
@@ -326,7 +328,7 @@ Usage: bundleutils update-bundle [OPTIONS]
 
 Options:
   -t, --target-dir DIRECTORY  The target directory to update the bundle.yaml
-                              file.  [required]
+                              file (defaults to CWD).
   -d, --description TEXT      Optional description for the bundle (also
                               BUNDLEUTILS_BUNDLE_DESCRIPTION).
   --help                      Show this message and exit.
@@ -382,6 +384,8 @@ Options:
   -s, --source-dir DIRECTORY  The source directory for the YAML documents
                               (BUNDLEUTILS_VALIDATE_SOURCE_DIR).  [required]
   -w, --ignore-warnings       Do not fail if warnings are found.
+  -r, --external-rbac FILE    Path to an external rbac.yaml from an Operations
+                              Center bundle.
   --help                      Show this message and exit.
 ------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils version [OPTIONS]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - [Why create it?](#why-create-it)
 - [Where can I run it?](#where-can-i-run-it)
 - [Commands](#commands)
+- [Help Pages](#help-pages)
 - [Local Development](#local-development)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -46,7 +47,7 @@ Runtime variants explained here include:
 
 For a summary of commands, see [explaining the main commands](./docs/explaining-commands.md)
 
-Help Pages
+## Help Pages
 
 <!-- START help-pages-doc -->
 ```mono

--- a/README.md
+++ b/README.md
@@ -56,14 +56,13 @@ Usage: bundleutils [OPTIONS] COMMAND [ARGS]...
 
 Options:
   -i, --interactive     Run in interactive mode.
-  -e, --env-file FILE   Optional bundle profiles file (or use
-                        BUNDLEUTILS_ENV).
-  -l, --log-level TEXT  The log level (or use BUNDLEUTILS_LOG_LEVEL).
+  -e, --env-file FILE   Optional bundle profiles file (BUNDLEUTILS_ENV).
+  -l, --log-level TEXT  The log level (BUNDLEUTILS_LOG_LEVEL).
   --help                Show this message and exit.
 
 Commands:
   audit                  Transform using the normalize.yaml but...
-  bootstrap              Bootstrap a bundle
+  bootstrap              Bootstrap a bundle.
   ci-sanitize-plugins    Sanitizes plugins (needs ci-start).
   ci-setup               Download CloudBees WAR file, and setup the...
   ci-start               Start CloudBees Server
@@ -82,7 +81,7 @@ Commands:
   update-plugins         Update plugins in the target directory.
   validate               Validate bundle in source dir against URL.
   version                Show the app version.
---------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils audit [OPTIONS]
 
   Transform using the normalize.yaml but obfuscating any sensitive data.
@@ -105,10 +104,10 @@ Options:
                               that is not shared with anyone. Changing this
                               value will result in different hashes.
   --help                      Show this message and exit.
---------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils bootstrap [OPTIONS]
 
-  Bootstrap a bundle
+  Bootstrap a bundle.
 
 Options:
   -s, --source-dir DIRECTORY   The bundle to be bootstrapped.
@@ -116,12 +115,11 @@ Options:
                                taken from URL.
   -p, --profile TEXT           The bundle profile to use.
   -u, --update TEXT            Should the bundle be updated if present.
-  -U, --url TEXT               The controller URL to bootstrap (or use
-                               JENKINS_URL).
+  -U, --url TEXT               The controller URL to bootstrap (JENKINS_URL).
   -v, --ci-version TEXT        Optional version (taken from the remote
                                instance otherwise).
   --help                       Show this message and exit.
---------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils ci-sanitize-plugins [OPTIONS]
 
   Sanitizes plugins (needs ci-start).
@@ -137,14 +135,15 @@ Options:
   -c, --custom-url TEXT       Add a custom URL, e.g. http://plugins-
                               repo/plugins/PNAME/PVERSION/PNAME.hpi
   --help                      Show this message and exit.
---------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils ci-setup [OPTIONS]
 
-  Download CloudBees WAR file, and setup the starter bundle. Env vars:
-  BUNDLEUTILS_CB_DOCKER_IMAGE_{CI_TYPE}: Docker image to use for the specified
-  CI type     BUNDLEUTILS_CB_WAR_DOWNLOAD_URL_{CI_TYPE}: WAR download URL to
-  use for the specified CI type     BUNDLEUTILS_SKOPEO_COPY_OPTS: options to
-  pass to skopeo copy command
+  Download CloudBees WAR file, and setup the starter bundle.
+
+  Env vars:
+      BUNDLEUTILS_CB_DOCKER_IMAGE_{CI_TYPE}: Docker image to use for the specified CI type
+      BUNDLEUTILS_CB_WAR_DOWNLOAD_URL_{CI_TYPE}: WAR download URL to use for the specified CI type
+      BUNDLEUTILS_SKOPEO_COPY_OPTS: options to pass to skopeo copy command
 
 Options:
   -H, --ci-server-home TEXT       Defaults to
@@ -157,7 +156,7 @@ Options:
                                   Path to a template bundle used to start the
                                   test server (defaults to in-built tempalte).
   --help                          Show this message and exit.
---------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils ci-start [OPTIONS]
 
   Start CloudBees Server
@@ -168,7 +167,7 @@ Options:
   -t, --ci-type TEXT         The type of the CloudBees server.
   -v, --ci-version TEXT      The version of the CloudBees WAR file.
   --help                     Show this message and exit.
---------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils ci-stop [OPTIONS]
 
   Stop CloudBees Server
@@ -179,7 +178,7 @@ Options:
   -t, --ci-type TEXT         The type of the CloudBees server.
   -v, --ci-version TEXT      The version of the CloudBees WAR file.
   --help                     Show this message and exit.
---------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils ci-validate [OPTIONS]
 
   Validate bundle against controller started with ci-start.
@@ -192,7 +191,7 @@ Options:
   -s, --source-dir DIRECTORY  The bundle to be validated.
   -w, --ignore-warnings       Do not fail if warnings are found.
   --help                      Show this message and exit.
---------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils completion [OPTIONS]
 
   Print the shell completion script
@@ -201,90 +200,97 @@ Options:
   -s, --shell [bash|fish|zsh]  The shell to generate completion script for.
                                [required]
   --help                       Show this message and exit.
---------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils config [OPTIONS]
 
   List evaluated config based on cwd and env file.
 
 Options:
   --help  Show this message and exit.
---------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils diff [OPTIONS] SRC1 SRC2
 
   Diff two YAML directories or files.
 
 Options:
   --help  Show this message and exit.
---------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils extract-name-from-url [OPTIONS]
 
-  Smart extraction of the controller name from the URL. Extracts NAME from the
-  following URL formats: - http://a.b.c/NAME/ - http://a.b.c/NAME -
-  https://a.b.c/NAME/ - https://a.b.c/NAME - http://NAME.b.c/ -
-  http://NAME.b.c - https://NAME.b.c/ - https://NAME.b.c
+  Smart extraction of the controller name from the URL.
+
+  Extracts NAME from the following URL formats:
+  - http://a.b.c/NAME/
+  - http://a.b.c/NAME
+  - https://a.b.c/NAME/
+  - https://a.b.c/NAME
+  - http://NAME.b.c/
+  - http://NAME.b.c
+  - https://NAME.b.c/
+  - https://NAME.b.c
 
 Options:
   -u, --url TEXT  The URL to extract the controller name from.
   --help          Show this message and exit.
---------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils fetch [OPTIONS]
 
   Fetch YAML documents from a URL or path.
 
 Options:
   -t, --target-dir DIRECTORY      The target directory for the YAML documents
-                                  (or use BUNDLEUTILS_FETCH_TARGET_DIR).
-  -p, --password TEXT             Password for basic authentication (or use
-                                  BUNDLEUTILS_PASSWORD).
-  -u, --username TEXT             Username for basic authentication (or use
-                                  BUNDLEUTILS_USERNAME).
-  -U, --url TEXT                  The URL to fetch YAML from (or use
-                                  BUNDLEUTILS_JENKINS_URL).
+                                  (BUNDLEUTILS_FETCH_TARGET_DIR).
+  -p, --password TEXT             Password for basic authentication
+                                  (BUNDLEUTILS_PASSWORD).
+  -u, --username TEXT             Username for basic authentication
+                                  (BUNDLEUTILS_USERNAME).
+  -U, --url TEXT                  The URL to fetch YAML from
+                                  (BUNDLEUTILS_JENKINS_URL).
   -C, --catalog-warnings-strategy TEXT
                                   Strategy for handling beekeeper warnings in
-                                  the plugin catalog (or use
-                                  BUNDLEUTILS_CATALOG_WARNINGS_STRATEGY).
+                                  the plugin catalog
+                                  (BUNDLEUTILS_CATALOG_WARNINGS_STRATEGY).
   -J, --plugins-json-merge-strategy TEXT
                                   Strategy for merging plugins from list into
-                                  the bundle (or use
-                                  BUNDLEUTILS_PLUGINS_JSON_MERGE_STRATEGY).
+                                  the bundle
+                                  (BUNDLEUTILS_PLUGINS_JSON_MERGE_STRATEGY).
   -j, --plugins-json-list-strategy TEXT
                                   Strategy for creating list from the plugins
-                                  json (or use
-                                  BUNDLEUTILS_PLUGINS_JSON_LIST_STRATEGY).
+                                  json
+                                  (BUNDLEUTILS_PLUGINS_JSON_LIST_STRATEGY).
   -O, --offline                   Save the export and plugin data to <target-
-                                  dir>-offline (or use
-                                  BUNDLEUTILS_FETCH_OFFLINE).
+                                  dir>-offline (BUNDLEUTILS_FETCH_OFFLINE).
   -c, --cap                       Use the envelope.json from the war file to
-                                  remove CAP plugin dependencies (or use
-                                  BUNDLEUTILS_FETCH_USE_CAP_ENVELOPE).
-  -P, --path FILE                 The path to fetch YAML from (or use
-                                  BUNDLEUTILS_PATH).
+                                  remove CAP plugin dependencies
+                                  (BUNDLEUTILS_FETCH_USE_CAP_ENVELOPE).
+  -P, --path FILE                 The path to fetch YAML from
+                                  (BUNDLEUTILS_PATH).
   -M, --plugin-json-path TEXT     The path to fetch JSON file from (found at /
                                   manage/pluginManager/api/json?pretty&depth=1
                                   &tree=plugins[*[*]]).
   --help                          Show this message and exit.
---------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils find-bundle-by-url [OPTIONS]
 
   Find a bundle by Jenkins URL and CI Version.
 
+  Use -v '.*' to match any version.
+
 Options:
-  -U, --url TEXT               The controller URL to test for (or use
-                               JENKINS_URL).
+  -U, --url TEXT               The controller URL to test for (JENKINS_URL).
   -v, --ci-version TEXT        Optional version (taken from the remote
                                instance otherwise).
   -b, --bundles-dir DIRECTORY  The directory containing the bundles.
   --help                       Show this message and exit.
---------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils help-pages [OPTIONS]
 
   Show all help pages by running 'bundleutils --help' at the global level and
-  then per sub command.
+  each sub command.
 
 Options:
   --help  Show this message and exit.
---------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils normalize [OPTIONS]
 
   Transform using the normalize.yaml for better comparison.
@@ -298,7 +304,7 @@ Options:
   -S, --strict                Fail when referencing non-existent files - warn
                               otherwise.
   --help                      Show this message and exit.
---------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils transform [OPTIONS]
 
   Transform using a custom transformation config.
@@ -312,7 +318,7 @@ Options:
   -S, --strict                Fail when referencing non-existent files - warn
                               otherwise.
   --help                      Show this message and exit.
---------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils update-bundle [OPTIONS]
 
   Update the bundle.yaml file in the target directory.
@@ -323,62 +329,60 @@ Options:
   -d, --description TEXT      Optional description for the bundle (also
                               BUNDLEUTILS_BUNDLE_DESCRIPTION).
   --help                      Show this message and exit.
---------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils update-plugins [OPTIONS]
 
   Update plugins in the target directory.
 
 Options:
   -t, --target-dir DIRECTORY      The target directory for the YAML documents
-                                  (or use BUNDLEUTILS_FETCH_TARGET_DIR).
-  -p, --password TEXT             Password for basic authentication (or use
-                                  BUNDLEUTILS_PASSWORD).
-  -u, --username TEXT             Username for basic authentication (or use
-                                  BUNDLEUTILS_USERNAME).
-  -U, --url TEXT                  The URL to fetch YAML from (or use
-                                  BUNDLEUTILS_JENKINS_URL).
+                                  (BUNDLEUTILS_FETCH_TARGET_DIR).
+  -p, --password TEXT             Password for basic authentication
+                                  (BUNDLEUTILS_PASSWORD).
+  -u, --username TEXT             Username for basic authentication
+                                  (BUNDLEUTILS_USERNAME).
+  -U, --url TEXT                  The URL to fetch YAML from
+                                  (BUNDLEUTILS_JENKINS_URL).
   -C, --catalog-warnings-strategy TEXT
                                   Strategy for handling beekeeper warnings in
-                                  the plugin catalog (or use
-                                  BUNDLEUTILS_CATALOG_WARNINGS_STRATEGY).
+                                  the plugin catalog
+                                  (BUNDLEUTILS_CATALOG_WARNINGS_STRATEGY).
   -J, --plugins-json-merge-strategy TEXT
                                   Strategy for merging plugins from list into
-                                  the bundle (or use
-                                  BUNDLEUTILS_PLUGINS_JSON_MERGE_STRATEGY).
+                                  the bundle
+                                  (BUNDLEUTILS_PLUGINS_JSON_MERGE_STRATEGY).
   -j, --plugins-json-list-strategy TEXT
                                   Strategy for creating list from the plugins
-                                  json (or use
-                                  BUNDLEUTILS_PLUGINS_JSON_LIST_STRATEGY).
+                                  json
+                                  (BUNDLEUTILS_PLUGINS_JSON_LIST_STRATEGY).
   -O, --offline                   Save the export and plugin data to <target-
-                                  dir>-offline (or use
-                                  BUNDLEUTILS_FETCH_OFFLINE).
+                                  dir>-offline (BUNDLEUTILS_FETCH_OFFLINE).
   -c, --cap                       Use the envelope.json from the war file to
-                                  remove CAP plugin dependencies (or use
-                                  BUNDLEUTILS_FETCH_USE_CAP_ENVELOPE).
-  -P, --path FILE                 The path to fetch YAML from (or use
-                                  BUNDLEUTILS_PATH).
+                                  remove CAP plugin dependencies
+                                  (BUNDLEUTILS_FETCH_USE_CAP_ENVELOPE).
+  -P, --path FILE                 The path to fetch YAML from
+                                  (BUNDLEUTILS_PATH).
   -M, --plugin-json-path TEXT     The path to fetch JSON file from (found at /
                                   manage/pluginManager/api/json?pretty&depth=1
                                   &tree=plugins[*[*]]).
   --help                          Show this message and exit.
---------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils validate [OPTIONS]
 
   Validate bundle in source dir against URL.
 
 Options:
-  -U, --url TEXT              The controller URL to validate agianst (or use
-                              BUNDLEUTILS_JENKINS_URL).
-  -u, --username TEXT         Username for basic authentication (or use
-                              BUNDLEUTILS_USERNAME).
-  -p, --password TEXT         Password for basic authentication (or use
-                              BUNDLEUTILS_PASSWORD).
-  -s, --source-dir DIRECTORY  The source directory for the YAML documents (or
-                              use BUNDLEUTILS_VALIDATE_SOURCE_DIR).
-                              [required]
+  -U, --url TEXT              The controller URL to validate agianst
+                              (BUNDLEUTILS_JENKINS_URL).
+  -u, --username TEXT         Username for basic authentication
+                              (BUNDLEUTILS_USERNAME).
+  -p, --password TEXT         Password for basic authentication
+                              (BUNDLEUTILS_PASSWORD).
+  -s, --source-dir DIRECTORY  The source directory for the YAML documents
+                              (BUNDLEUTILS_VALIDATE_SOURCE_DIR).  [required]
   -w, --ignore-warnings       Do not fail if warnings are found.
   --help                      Show this message and exit.
---------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils version [OPTIONS]
 
   Show the app version.

--- a/bundleutilspkg/scripts/bundleutils.py
+++ b/bundleutilspkg/scripts/bundleutils.py
@@ -483,12 +483,33 @@ def bootstrap(ctx, source_dir, source_base, profile, update, url, ci_version):
             die(f'No bundle profile found for {bootstrap_profile}')
 
 @cli.command()
+@click.pass_context
+def help_pages(ctx):
+    """
+    Show all help pages by running 'bundleutils --help' at the global level and then per sub command.
+    """
+    click.echo(ctx.parent.get_help())
+    # get all sub commands in alphabetical order
+    commands = sorted(cli.commands.keys())
+
+    for key in commands:
+        command = cli.commands[key]
+        click.echo('-' * 80)
+        click.echo(command.get_help(ctx.parent).replace('Usage: bundleutils', f'Usage: bundleutils {command.name}'))
+
+@cli.command()
 @server_options
 @click.option('-s', '--source-dir', type=click.Path(file_okay=False, dir_okay=True), help=f'The bundle to be validated (startup will use the plugins from here).')
 @click.option('-T', '--ci-bundle-template', type=click.Path(file_okay=False, dir_okay=True), required=False, help=f'Path to a template bundle used to start the test server (defaults to in-built tempalte).')
 @click.pass_context
 def ci_setup(ctx, ci_version, ci_type, ci_server_home, source_dir, ci_bundle_template):
-    """Download CloudBees WAR file, and setup the starter bundle"""
+    """
+    Download CloudBees WAR file, and setup the starter bundle.
+    Env vars:
+        BUNDLEUTILS_CB_DOCKER_IMAGE_{CI_TYPE}: Docker image to use for the specified CI type
+        BUNDLEUTILS_CB_WAR_DOWNLOAD_URL_{CI_TYPE}: WAR download URL to use for the specified CI type
+        BUNDLEUTILS_SKOPEO_COPY_OPTS: options to pass to skopeo copy command
+    """
     set_logging(ctx)
     ci_version, ci_type, ci_server_home = server_options_null_check(ci_version, ci_type, ci_server_home)
     source_dir = null_check(source_dir, SOURCE_DIR_ARG, BUNDLEUTILS_SETUP_SOURCE_DIR)

--- a/bundleutilspkg/scripts/bundleutils.py
+++ b/bundleutilspkg/scripts/bundleutils.py
@@ -1965,11 +1965,15 @@ def _update_bundle(target_dir, description=None):
                 files = [exact_match]
                 break
 
-        # Add list of YAML files starting with the prefix
-        for prefix in prefixes:
-            files += sorted(glob.glob(os.path.join(target_dir, f'{prefix}.*.yaml')))
+        # Add list of YAML files matching .*prefix.* and ending with .yaml
+        for file in os.listdir(target_dir):
+            if re.match(rf'.*{prefix}.*\.yaml', file) and not file == f'{prefix}.yaml':
+                files.append(os.path.join(target_dir, file))
+
         # remove any empty files
-        files = [file for file in files if _file_check(file)]
+        files = sorted([file for file in files if _file_check(file)])
+        for file in files:
+            logging.debug(f'File for {key}: {file}')
 
         # special case for 'plugins'. If any of the files does not contain the yaml key 'plugins', remove the key from the data
         if key == 'plugins':

--- a/bundleutilspkg/scripts/bundleutils.py
+++ b/bundleutilspkg/scripts/bundleutils.py
@@ -1,6 +1,8 @@
 from enum import Enum, auto
 import hashlib
 import json
+import subprocess
+import tempfile
 import jsonpatch
 import jsonpointer
 import zipfile
@@ -53,6 +55,7 @@ BUNDLEUTILS_BOOTSTRAP_SOURCE_BASE = 'BUNDLEUTILS_BOOTSTRAP_SOURCE_BASE'
 BUNDLEUTILS_BOOTSTRAP_PROFILE = 'BUNDLEUTILS_BOOTSTRAP_PROFILE'
 BUNDLEUTILS_BOOTSTRAP_UPDATE = 'BUNDLEUTILS_BOOTSTRAP_UPDATE'
 BUNDLEUTILS_SETUP_SOURCE_DIR = 'BUNDLEUTILS_SETUP_SOURCE_DIR'
+BUNDLEUTILS_VALIDATE_EXTERNAL_RBAC = 'BUNDLEUTILS_VALIDATE_EXTERNAL_RBAC'
 BUNDLEUTILS_VALIDATE_SOURCE_DIR = 'BUNDLEUTILS_VALIDATE_SOURCE_DIR'
 BUNDLEUTILS_TRANSFORM_SOURCE_DIR = 'BUNDLEUTILS_TRANSFORM_SOURCE_DIR'
 BUNDLEUTILS_TRANSFORM_TARGET_DIR = 'BUNDLEUTILS_TRANSFORM_TARGET_DIR'
@@ -102,6 +105,7 @@ CI_TYPE_ARG = 'ci_type'
 CI_SERVER_HOME_ARG = 'ci_server_home'
 SOURCE_DIR_ARG = 'source_dir'
 SOURCE_BASE_ARG = 'source_base'
+EXTERNAL_RBAC_ARG = 'external_rbac'
 TARGET_DIR_ARG = 'target_dir'
 PLUGIN_JSON_ADDITIONS_ARG = 'plugin_json_additions'
 PLUGIN_JSON_URL_ARG = 'plugin_json_url'
@@ -538,8 +542,9 @@ def ci_setup(ctx, ci_version, ci_type, ci_server_home, source_dir, ci_bundle_tem
 @server_options
 @click.option('-s', '--source-dir', type=click.Path(file_okay=False, dir_okay=True), help=f'The bundle to be validated.')
 @click.option('-w', '--ignore-warnings', default=False, is_flag=True, help=f'Do not fail if warnings are found.')
+@click.option('-r', '--external-rbac', type=click.Path(file_okay=True, dir_okay=False), help=f'Path to an external rbac.yaml from an Operations Center bundle.')
 @click.pass_context
-def ci_validate(ctx, ci_version, ci_type, ci_server_home, source_dir, ignore_warnings):
+def ci_validate(ctx, ci_version, ci_type, ci_server_home, source_dir, ignore_warnings, external_rbac):
     """Validate bundle against controller started with ci-start."""
     set_logging(ctx)
     ci_version, ci_type, ci_server_home = server_options_null_check(ci_version, ci_type, ci_server_home)
@@ -549,7 +554,7 @@ def ci_validate(ctx, ci_version, ci_type, ci_server_home, source_dir, ignore_war
     jenkins_manager = JenkinsServerManager(ci_type, ci_version, ci_server_home)
     server_url, username, password = jenkins_manager.get_server_details()
     logging.debug(f"Server URL: {server_url}, Username: {username}, Password: {password}")
-    _validate(server_url, username, password, source_dir, ignore_warnings)
+    _validate(server_url, username, password, source_dir, ignore_warnings, external_rbac)
 
 @cli.command()
 @server_options
@@ -844,17 +849,24 @@ def null_check(ctx, obj, obj_name, obj_env_var=None, mandatory=True, default='')
 @click.option('-p', '--password', help=f'Password for basic authentication ({BUNDLEUTILS_PASSWORD}).')
 @click.option('-s', '--source-dir', required=True, type=click.Path(file_okay=False, dir_okay=True), help=f'The source directory for the YAML documents ({BUNDLEUTILS_VALIDATE_SOURCE_DIR}).')
 @click.option('-w', '--ignore-warnings', default=False, is_flag=True, help=f'Do not fail if warnings are found.')
+@click.option('-r', '--external-rbac', type=click.Path(file_okay=True, dir_okay=False), help=f'Path to an external rbac.yaml from an Operations Center bundle.')
 @click.pass_context
-def validate(ctx, url, username, password, source_dir, ignore_warnings):
+def validate(ctx, url, username, password, source_dir, ignore_warnings, external_rbac):
     """Validate bundle in source dir against URL."""
     set_logging(ctx)
-    _validate(url, username, password, source_dir, ignore_warnings)
+    _validate(url, username, password, source_dir, ignore_warnings, external_rbac)
 
-def _validate(url, username, password, source_dir, ignore_warnings):
+def _validate(url, username, password, source_dir, ignore_warnings, external_rbac):
     username = null_check(username, 'username', BUNDLEUTILS_USERNAME)
     password = null_check(password, 'password', BUNDLEUTILS_PASSWORD)
     source_dir = null_check(source_dir, 'source directory', BUNDLEUTILS_VALIDATE_SOURCE_DIR)
+    external_rbac = null_check(external_rbac, EXTERNAL_RBAC_ARG, BUNDLEUTILS_VALIDATE_EXTERNAL_RBAC, False)
     url = lookup_url(url)
+
+    if external_rbac:
+        if not os.path.exists(external_rbac):
+            die(f"RBAC configuration file not found in {external_rbac}")
+        logging.info(f"Using RBAC from {external_rbac}")
 
     # if the url does end with /casc-bundle-mgnt/casc-bundle-validate, append it
     if validate_url_path not in url:
@@ -864,13 +876,23 @@ def _validate(url, username, password, source_dir, ignore_warnings):
     headers = { 'Content-Type': 'application/zip' }
     if username and password:
         headers['Authorization'] = 'Basic ' + base64.b64encode(f'{username}:{password}'.encode('utf-8')).decode('utf-8')
-    # zip and post the YAML to the URL
-    with zipfile.ZipFile('bundle.zip', 'w') as zip_ref:
+
+    # create a temporary directory to store the bundle
+    with tempfile.TemporaryDirectory() as temp_dir:
+        logging.debug(f"Copying bundle files to {temp_dir}")
         for filename in os.listdir(source_dir):
-            zip_ref.write(os.path.join(source_dir, filename), filename)
-    with open('bundle.zip', 'rb') as f:
-        # post as binary file
-        response = requests.post(url, headers=headers, data=f)
+            subprocess.run(['cp', os.path.join(source_dir, filename), temp_dir], check=True)
+        if external_rbac:
+            logging.debug(f"Copying external RBAC file to {temp_dir}")
+            subprocess.run(['cp', external_rbac, temp_dir], check=True)
+        _update_bundle(temp_dir)
+        # zip and post the YAML to the URL
+        with zipfile.ZipFile('bundle.zip', 'w') as zip_ref:
+            for filename in os.listdir(temp_dir):
+                zip_ref.write(os.path.join(temp_dir, filename), filename)
+        with open('bundle.zip', 'rb') as f:
+            # post as binary file
+            response = requests.post(url, headers=headers, data=f)
     response.raise_for_status()
     # delete the zip file
     os.remove('bundle.zip')
@@ -1959,7 +1981,7 @@ def remove_empty_keys(data):
     return data
 
 @cli.command()
-@click.option('-t', '--target-dir', 'target_dir', required=True, type=click.Path(file_okay=False, dir_okay=True), help=f'The target directory to update the bundle.yaml file.')
+@click.option('-t', '--target-dir', 'target_dir', type=click.Path(file_okay=False, dir_okay=True), help=f'The target directory to update the bundle.yaml file (defaults to CWD).')
 @click.option('-d', '--description', 'description', help=f'Optional description for the bundle (also {BUNDLEUTILS_BUNDLE_DESCRIPTION}).')
 @click.pass_context
 def update_bundle(ctx, target_dir, description):
@@ -1967,10 +1989,13 @@ def update_bundle(ctx, target_dir, description):
     set_logging(ctx)
     _update_bundle(target_dir, description)
 
-def _update_bundle(target_dir, description=None):
+@click.pass_context
+def _update_bundle(ctx, target_dir, description=None):
     description = null_check(description, 'description', BUNDLEUTILS_BUNDLE_DESCRIPTION, False)
     keys = ['jcasc', 'items', 'plugins', 'rbac', 'catalog', 'variables']
 
+    if not target_dir:
+        target_dir = ctx.obj.get(ORIGINAL_CWD)
     logging.info(f'Updating bundle in {target_dir}')
     # Load the YAML file
     with open(os.path.join(target_dir, 'bundle.yaml'), 'r') as file:

--- a/bundleutilspkg/scripts/bundleutils.py
+++ b/bundleutilspkg/scripts/bundleutils.py
@@ -510,8 +510,8 @@ def ci_setup(ctx, ci_version, ci_type, ci_server_home, source_dir, ci_bundle_tem
 
     \b
     Env vars:
-        BUNDLEUTILS_CB_DOCKER_IMAGE_{CI_TYPE}: Docker image to use for the specified CI type
-        BUNDLEUTILS_CB_WAR_DOWNLOAD_URL_{CI_TYPE}: WAR download URL to use for the specified CI type
+        BUNDLEUTILS_CB_DOCKER_IMAGE_{CI_TYPE}: Docker image for the CI_TYPE (MM, OC)
+        BUNDLEUTILS_CB_WAR_DOWNLOAD_URL_{CI_TYPE}: WAR download URL for the CI_TYPE (CM, OC_TRADITIONAL)
         BUNDLEUTILS_SKOPEO_COPY_OPTS: options to pass to skopeo copy command
     """
     set_logging(ctx)

--- a/bundleutilspkg/scripts/bundleutils.py
+++ b/bundleutilspkg/scripts/bundleutils.py
@@ -150,8 +150,8 @@ def get_name_from_enum(my_enum):
 
 
 def common_options(func):
-    func = click.option('-l', '--log-level', default=os.environ.get(BUNDLEUTILS_LOG_LEVEL, 'INFO'), help=f'The log level (or use {BUNDLEUTILS_LOG_LEVEL}).')(func)
-    func = click.option('-e', '--env-file', default=os.environ.get(BUNDLEUTILS_ENV, ''), type=click.Path(file_okay=True, dir_okay=False), help=f'Optional bundle profiles file (or use {BUNDLEUTILS_ENV}).')(func)
+    func = click.option('-l', '--log-level', default=os.environ.get(BUNDLEUTILS_LOG_LEVEL, 'INFO'), help=f'The log level ({BUNDLEUTILS_LOG_LEVEL}).')(func)
+    func = click.option('-e', '--env-file', default=os.environ.get(BUNDLEUTILS_ENV, ''), type=click.Path(file_okay=True, dir_okay=False), help=f'Optional bundle profiles file ({BUNDLEUTILS_ENV}).')(func)
     func = click.option('-i', '--interactive', default=False, is_flag=True, help=f'Run in interactive mode.')(func)
     return func
 
@@ -163,16 +163,16 @@ def server_options(func):
 
 def fetch_options(func):
     func = click.option('-M', '--plugin-json-path', help=f'The path to fetch JSON file from (found at {plugin_json_url_path}).')(func)
-    func = click.option('-P', '--path', 'path', type=click.Path(file_okay=True, dir_okay=False), help=f'The path to fetch YAML from (or use {BUNDLEUTILS_PATH}).')(func)
-    func = click.option('-c', '--cap', default=False, is_flag=True, help=f'Use the envelope.json from the war file to remove CAP plugin dependencies (or use {BUNDLEUTILS_FETCH_USE_CAP_ENVELOPE}).')(func)
-    func = click.option('-O', '--offline', default=False, is_flag=True, help=f'Save the export and plugin data to <target-dir>-offline (or use {BUNDLEUTILS_FETCH_OFFLINE}).')(func)
-    func = click.option('-j', '--plugins-json-list-strategy', help=f'Strategy for creating list from the plugins json (or use {BUNDLEUTILS_PLUGINS_JSON_LIST_STRATEGY}).')(func)
-    func = click.option('-J', '--plugins-json-merge-strategy', help=f'Strategy for merging plugins from list into the bundle (or use {BUNDLEUTILS_PLUGINS_JSON_MERGE_STRATEGY}).')(func)
-    func = click.option('-C', '--catalog-warnings-strategy', help=f'Strategy for handling beekeeper warnings in the plugin catalog (or use {BUNDLEUTILS_CATALOG_WARNINGS_STRATEGY}).')(func)
-    func = click.option('-U', '--url', 'url', help=f'The URL to fetch YAML from (or use {BUNDLEUTILS_JENKINS_URL}).')(func)
-    func = click.option('-u', '--username', help=f'Username for basic authentication (or use {BUNDLEUTILS_USERNAME}).')(func)
-    func = click.option('-p', '--password', help=f'Password for basic authentication (or use {BUNDLEUTILS_PASSWORD}).')(func)
-    func = click.option('-t', '--target-dir', type=click.Path(file_okay=False, dir_okay=True), help=f'The target directory for the YAML documents (or use {BUNDLEUTILS_FETCH_TARGET_DIR}).')(func)
+    func = click.option('-P', '--path', 'path', type=click.Path(file_okay=True, dir_okay=False), help=f'The path to fetch YAML from ({BUNDLEUTILS_PATH}).')(func)
+    func = click.option('-c', '--cap', default=False, is_flag=True, help=f'Use the envelope.json from the war file to remove CAP plugin dependencies ({BUNDLEUTILS_FETCH_USE_CAP_ENVELOPE}).')(func)
+    func = click.option('-O', '--offline', default=False, is_flag=True, help=f'Save the export and plugin data to <target-dir>-offline ({BUNDLEUTILS_FETCH_OFFLINE}).')(func)
+    func = click.option('-j', '--plugins-json-list-strategy', help=f'Strategy for creating list from the plugins json ({BUNDLEUTILS_PLUGINS_JSON_LIST_STRATEGY}).')(func)
+    func = click.option('-J', '--plugins-json-merge-strategy', help=f'Strategy for merging plugins from list into the bundle ({BUNDLEUTILS_PLUGINS_JSON_MERGE_STRATEGY}).')(func)
+    func = click.option('-C', '--catalog-warnings-strategy', help=f'Strategy for handling beekeeper warnings in the plugin catalog ({BUNDLEUTILS_CATALOG_WARNINGS_STRATEGY}).')(func)
+    func = click.option('-U', '--url', 'url', help=f'The URL to fetch YAML from ({BUNDLEUTILS_JENKINS_URL}).')(func)
+    func = click.option('-u', '--username', help=f'Username for basic authentication ({BUNDLEUTILS_USERNAME}).')(func)
+    func = click.option('-p', '--password', help=f'Password for basic authentication ({BUNDLEUTILS_PASSWORD}).')(func)
+    func = click.option('-t', '--target-dir', type=click.Path(file_okay=False, dir_okay=True), help=f'The target directory for the YAML documents ({BUNDLEUTILS_FETCH_TARGET_DIR}).')(func)
     return func
 
 
@@ -349,6 +349,7 @@ def set_logging(ctx):
 def cli(ctx, log_level, env_file, interactive):
     """A tool to fetch and transform YAML documents."""
     ctx.ensure_object(dict)
+    ctx.max_content_width=120
     ctx.obj[ENV_FILE_ARG] = env_file
     ctx.obj[INTERACTIVE_ARG] = interactive
     if not ctx.obj.get(BUNDLEUTILS_LOG_LEVEL, ''):
@@ -359,7 +360,6 @@ def cli(ctx, log_level, env_file, interactive):
         ctx.obj[ORIGINAL_CWD] = os.getcwd()
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
-
 
 def yaml2dict(yamlFile):
     dict_res = {}
@@ -410,10 +410,12 @@ def lookup_url(url, default_url = '', mandatory = True):
 @click.option('-S', '--source-base', type=click.Path(file_okay=False, dir_okay=True), help=f'Specify parent dir of source-dir, bundle name taken from URL.')
 @click.option('-p', '--profile', help=f'The bundle profile to use.')
 @click.option('-u', '--update', help=f'Should the bundle be updated if present.')
-@click.option('-U', '--url', help=f'The controller URL to bootstrap (or use JENKINS_URL).')
+@click.option('-U', '--url', help=f'The controller URL to bootstrap (JENKINS_URL).')
 @click.option('-v', '--ci-version', type=click.STRING, help=f'Optional version (taken from the remote instance otherwise).')
 def bootstrap(ctx, source_dir, source_base, profile, update, url, ci_version):
-    """Bootstrap a bundle"""
+    """
+    Bootstrap a bundle.
+    """
     _check_for_env_file(ctx)
     # no bundle_profiles found, no need to check
     if not ctx.obj.get(BUNDLE_PROFILES, ''):
@@ -486,7 +488,7 @@ def bootstrap(ctx, source_dir, source_base, profile, update, url, ci_version):
 @click.pass_context
 def help_pages(ctx):
     """
-    Show all help pages by running 'bundleutils --help' at the global level and then per sub command.
+    Show all help pages by running 'bundleutils --help' at the global level and each sub command.
     """
     click.echo(ctx.parent.get_help())
     # get all sub commands in alphabetical order
@@ -494,7 +496,7 @@ def help_pages(ctx):
 
     for key in commands:
         command = cli.commands[key]
-        click.echo('-' * 80)
+        click.echo('-' * 120)
         click.echo(command.get_help(ctx.parent).replace('Usage: bundleutils', f'Usage: bundleutils {command.name}'))
 
 @cli.command()
@@ -505,6 +507,8 @@ def help_pages(ctx):
 def ci_setup(ctx, ci_version, ci_type, ci_server_home, source_dir, ci_bundle_template):
     """
     Download CloudBees WAR file, and setup the starter bundle.
+
+    \b
     Env vars:
         BUNDLEUTILS_CB_DOCKER_IMAGE_{CI_TYPE}: Docker image to use for the specified CI type
         BUNDLEUTILS_CB_WAR_DOWNLOAD_URL_{CI_TYPE}: WAR download URL to use for the specified CI type
@@ -723,6 +727,8 @@ def version():
 def extract_name_from_url(url):
     """
     Smart extraction of the controller name from the URL.
+
+    \b
     Extracts NAME from the following URL formats:
     - http://a.b.c/NAME/
     - http://a.b.c/NAME
@@ -748,12 +754,16 @@ def _extract_name_from_url(url):
         return subdomain
 
 @cli.command()
-@click.option('-U', '--url', help=f'The controller URL to test for (or use JENKINS_URL).')
+@click.option('-U', '--url', help=f'The controller URL to test for (JENKINS_URL).')
 @click.option('-v', '--ci-version', type=click.STRING, help=f'Optional version (taken from the remote instance otherwise).')
 @click.option('-b', '--bundles-dir', type=click.Path(file_okay=False, dir_okay=True), help=f'The directory containing the bundles.')
 @click.pass_context
 def find_bundle_by_url(ctx, url, ci_version, bundles_dir):
-    """Find a bundle by Jenkins URL and CI Version."""
+    """
+    Find a bundle by Jenkins URL and CI Version.
+
+    Use -v '.*' to match any version.
+    """
     set_logging(ctx)
     if not ctx.obj.get(BUNDLE_PROFILES, ''):  # if no bundle profiles are found, exit
         logging.error("No bundle profiles found. Exiting.")
@@ -829,10 +839,10 @@ def null_check(ctx, obj, obj_name, obj_env_var=None, mandatory=True, default='')
     return obj
 
 @cli.command()
-@click.option('-U', '--url', help=f'The controller URL to validate agianst (or use {BUNDLEUTILS_JENKINS_URL}).')
-@click.option('-u', '--username', help=f'Username for basic authentication (or use {BUNDLEUTILS_USERNAME}).')
-@click.option('-p', '--password', help=f'Password for basic authentication (or use {BUNDLEUTILS_PASSWORD}).')
-@click.option('-s', '--source-dir', required=True, type=click.Path(file_okay=False, dir_okay=True), help=f'The source directory for the YAML documents (or use {BUNDLEUTILS_VALIDATE_SOURCE_DIR}).')
+@click.option('-U', '--url', help=f'The controller URL to validate agianst ({BUNDLEUTILS_JENKINS_URL}).')
+@click.option('-u', '--username', help=f'Username for basic authentication ({BUNDLEUTILS_USERNAME}).')
+@click.option('-p', '--password', help=f'Password for basic authentication ({BUNDLEUTILS_PASSWORD}).')
+@click.option('-s', '--source-dir', required=True, type=click.Path(file_okay=False, dir_okay=True), help=f'The source directory for the YAML documents ({BUNDLEUTILS_VALIDATE_SOURCE_DIR}).')
 @click.option('-w', '--ignore-warnings', default=False, is_flag=True, help=f'Do not fail if warnings are found.')
 @click.pass_context
 def validate(ctx, url, username, password, source_dir, ignore_warnings):

--- a/bundleutilspkg/server_management/server_manager.py
+++ b/bundleutilspkg/server_management/server_manager.py
@@ -185,6 +185,7 @@ class JenkinsServerManager:
         """Create a startup bundle from the specified source directory and bundle template."""
         if not plugin_files:
             self.die(f"Plugin files not found in {plugin_files}")
+        logging.info(f"Using plugin files: {plugin_files}")
         # the validation template is a directory containing the configuration files to be used
         if not validation_template or os.path.exists(validation_template):
             # check if the validation-template directory exists in the current directory
@@ -206,8 +207,10 @@ class JenkinsServerManager:
                 src_file = os.path.join(root, file)
                 dest_file = os.path.join(self.target_jenkins_home_casc_startup_bundle, os.path.relpath(src_file, validation_template))
                 os.makedirs(os.path.dirname(dest_file), exist_ok=True)
+                logging.debug(f"Copying file {src_file} to {dest_file}")
                 subprocess.run(['cp', src_file, dest_file], check=True)
         for plugin_file in plugin_files:
+            logging.debug(f"Copying plugin file {plugin_file} to {self.target_jenkins_home_casc_startup_bundle}")
             subprocess.run(['cp', plugin_file, self.target_jenkins_home_casc_startup_bundle], check=True)
         logging.info(f"Created startup bundle in {self.target_jenkins_home_casc_startup_bundle}")
 

--- a/bundleutilspkg/server_management/server_manager.py
+++ b/bundleutilspkg/server_management/server_manager.py
@@ -62,8 +62,8 @@ class JenkinsServerManager:
         """
         Set the CloudBees Docker image and WAR download URL based on the ci_type and ci_version.
         Env vars:
-            BUNDLEUTILS_CB_DOCKER_IMAGE_{CI_TYPE}: Docker image to use for the specified CI type
-            BUNDLEUTILS_CB_WAR_DOWNLOAD_URL_{CI_TYPE}: WAR download URL to use for the specified CI type
+            BUNDLEUTILS_CB_DOCKER_IMAGE_{CI_TYPE}: Docker image for the CI_TYPE (MM, OC)
+            BUNDLEUTILS_CB_WAR_DOWNLOAD_URL_{CI_TYPE}: WAR download URL for the CI_TYPE (CM, OC_TRADITIONAL)
         """
         cb_downloads_url = "https://downloads.cloudbees.com/cloudbees-core/traditional"
         cb_docker_image = None

--- a/scripts/update_readme.sh
+++ b/scripts/update_readme.sh
@@ -16,7 +16,7 @@ tmpfile=$(mktemp)
 # Extract policies data from each YAML file and add to the temporary file
 # shellcheck disable=SC1090
 source "${venv_activate}"
-echo '```sh' > "$tmpfile"
+echo '```mono' > "$tmpfile"
 bundleutils help-pages >> "$tmpfile"
 echo '```' >> "$tmpfile"
 

--- a/scripts/update_readme.sh
+++ b/scripts/update_readme.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+git_root=$(git rev-parse --show-toplevel)
+venv_activate="${git_root}/.venv/bin/activate"
+# Ensure .venv created
+if [ ! -f "${venv_activate}" ]; then
+    echo "Please create a virtual environment .venv in the project root directory."
+    exit 1
+fi
+
+# Create a temporary file to store the new policy documentation
+tmpfile=$(mktemp)
+
+# Extract policies data from each YAML file and add to the temporary file
+# shellcheck disable=SC1090
+source "${venv_activate}"
+echo '```sh' > "$tmpfile"
+bundleutils help-pages >> "$tmpfile"
+echo '```' >> "$tmpfile"
+
+# Check if any policy data was extracted
+if [[ -s $tmpfile ]]; then
+    # Replace the old policy section in README.md with the new content
+    mv "$tmpfile" new_section.md
+    awk '
+        /<!-- START help-pages-doc -->/ { print; found=1; while (getline < "new_section.md") print; next }
+        /<!-- END help-pages-doc -->/ { found=0 }
+        !found
+    ' README.md > README.tmp && mv README.tmp README.md
+fi
+
+# Cleanup
+rm -f "$tmpfile" new_section.md


### PR DESCRIPTION
Big release with a number of improvements:

### Help Pages

Added the `help-pages` command to print out all the commands usage pages

- this will allow a more help page driven documentation
- added a `pre-commit` hook to automatically update the README with the latest usage pages

### Bundle Validation Improvements

- multiple plugin files are now allowed when validating a bundle
- added options for downloading from non-standard repositories using the env vars below

```mono
      BUNDLEUTILS_CB_DOCKER_IMAGE_{CI_TYPE}: Docker image for the CI_TYPE (MM, OC)
      BUNDLEUTILS_CB_WAR_DOWNLOAD_URL_{CI_TYPE}: WAR download URL for the CI_TYPE (CM, OC_TRADITIONAL)
      BUNDLEUTILS_SKOPEO_COPY_OPTS: options to pass to skopeo copy command
```

### External RBAC option

- added the `external_rbac` option to simulate getting the `rbac.yaml` from the operation center if so configured