### PR TITLE
Option to use URL only as input + other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,16 @@ Usage: bundleutils [OPTIONS] COMMAND [ARGS]...
   A tool to fetch and transform YAML documents.
 
 Options:
-  -i, --interactive     Run in interactive mode.
-  -e, --env-file FILE   Optional bundle profiles file (BUNDLEUTILS_ENV).
-  -l, --log-level TEXT  The log level (BUNDLEUTILS_LOG_LEVEL).
-  --help                Show this message and exit.
+  -a, --auto-env-append-version  Append the current version to the bundle
+                                 directory
+                                 (BUNDLEUTILS_AUTO_ENV_APPEND_VERSION).
+  -u, --auto-env-url-only        Determine env vars via URL only
+                                 (BUNDLEUTILS_AUTO_ENV_USE_URL_ONLY).
+  -i, --interactive              Run in interactive mode.
+  -e, --env-file FILE            Optional bundle profiles file
+                                 (BUNDLEUTILS_ENV).
+  -l, --log-level TEXT           The log level (BUNDLEUTILS_LOG_LEVEL).
+  --help                         Show this message and exit.
 
 Commands:
   audit                           Transform using the normalize.yaml but...
@@ -69,6 +75,7 @@ Commands:
   diff-merged                     Diff two bundle directories by...
   extract-from-pattern            Extract the controller name from a...
   extract-name-from-url           Smart extraction of the controller...
+  extract-version-from-url        Get the instance version from the URL.
   fetch                           Fetch YAML documents from a URL or path.
   find-bundle-by-url              Find a bundle by Jenkins URL and CI...
   find-bundles
@@ -227,7 +234,8 @@ Usage: bundleutils config [OPTIONS]
   List evaluated config based on cwd and env file.
 
 Options:
-  --help  Show this message and exit.
+  -k, --key TEXT  Return the value of the key or an error if not found.
+  --help          Show this message and exit.
 ------------------------------------------------------------------------------------------------------------------------
 Usage: bundleutils delete [OPTIONS]
 
@@ -300,6 +308,14 @@ Usage: bundleutils extract-name-from-url [OPTIONS]
   - http://NAME.b.c
   - https://NAME.b.c/
   - https://NAME.b.c
+
+Options:
+  -u, --url TEXT  The URL to extract the controller name from.
+  --help          Show this message and exit.
+------------------------------------------------------------------------------------------------------------------------
+Usage: bundleutils extract-version-from-url [OPTIONS]
+
+  Get the instance version from the URL.
 
 Options:
   -u, --url TEXT  The URL to extract the controller name from.

--- a/bundleutilspkg/src/bundleutilspkg/bundleutils.py
+++ b/bundleutilspkg/src/bundleutilspkg/bundleutils.py
@@ -310,8 +310,9 @@ def transform_options(func):
 def _set_env_if_not_set(prefix, env_var, value):
     if not os.environ.get(env_var, ''):
         logging.info(f'{prefix} environment variable: {env_var}={value}')
-        os.environ[env_var] = value
+        os.environ[env_var] = str(value)
 
+@click.pass_context
 def _check_for_env_file(ctx):
     if ctx.obj.get(BUNDLEUTILS_ENV, ''):
         # we have an env file, no need to check for auto vars
@@ -373,6 +374,7 @@ def _check_for_env_file(ctx):
         ctx.obj[BUNDLEUTILS_ENV] = ''
         logging.debug(f'No env file provided or found')
 
+@click.pass_context
 def _check_cwd_for_bundle_auto_vars(ctx, switch_dirs = True):
     """Check the current working directory for a bundle.yaml file and set the auto vars if found"""
     # no bundle_profiles found, no need to check
@@ -470,11 +472,11 @@ def _check_cwd_for_bundle_auto_vars(ctx, switch_dirs = True):
                     logging.info(f'Replacing {key}={value} with {new_value}')
                     os.environ[key] = new_value
 
+@click.pass_context
 def _check_url_and_determine_env_vars(ctx):
     """Create the environment variables based on the URL"""
     # no bundle_profiles found, no need to check
 
-    env_vars = {}
     cwd = os.getcwd()
     if not ctx.obj.get(ORIGINAL_CWD, ''):
         ctx.obj[ORIGINAL_CWD] = cwd
@@ -487,19 +489,17 @@ def _check_url_and_determine_env_vars(ctx):
 
     bundle_name = instance_name
     last_known_bundle_name = ''
-    append_version = ctx.obj.get('auto_env_append_version', False)
+    append_version = is_truthy(ctx.obj.get('auto_env_append_version'))
     if append_version:
         bundle_name = f"{instance_name}-{version}"
         # if the bundle name directory does not exist, create it
         if not os.path.exists(bundle_name):
             # find the last directory that matches the pattern "{instance_name}-x.x.x.x"
-            regex = re.compile(f"^{instance_name}-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$")
+            regex = re.compile(rf"^{instance_name}-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$")
             for dir in reversed(sorted(os.listdir(cwd), key=lambda x: x.lower())):
                 if regex.match(dir):
                     last_known_bundle_name = dir
                     break
-
-
 
     # get target dir values
     bundle_target_dir = os.path.join(cwd, bundle_name)
@@ -534,14 +534,18 @@ def _check_url_and_determine_env_vars(ctx):
                 os.environ[key] = new_value
 
 def is_truthy(value):
-    return value.lower() in ['true', '1', 't', 'y', 'yes']
+    """Check if a value is truthy."""
+    if value is None:
+        return False
+    return str(value).lower() in ['true', '1', 't', 'y', 'yes']
 
+@click.pass_context
 def set_logging(ctx, switch_dirs = True):
     if ctx.obj.get('auto_env_url_only', False):
-        _check_url_and_determine_env_vars(ctx)
+        _check_url_and_determine_env_vars()
     else:
-        _check_for_env_file(ctx)
-        _check_cwd_for_bundle_auto_vars(ctx, switch_dirs)
+        _check_for_env_file()
+        _check_cwd_for_bundle_auto_vars(switch_dirs)
 
 @click.group(invoke_without_command=True)
 @common_options
@@ -783,7 +787,7 @@ def ci_setup(ctx, ci_version, ci_type, ci_server_home, source_dir, ci_bundle_tem
             BUNDLEUTILS_CB_DOCKER_IMAGE_MM=my-registry/cloudbees-core-mm
 
     """
-    set_logging(ctx)
+    set_logging()
     ci_version, ci_type, ci_server_home = server_options_null_check(ci_version, ci_type, ci_server_home)
     source_dir = null_check(source_dir, SOURCE_DIR_ARG, BUNDLEUTILS_SETUP_SOURCE_DIR)
     source_dir = os.path.normpath(source_dir)
@@ -1007,7 +1011,7 @@ def merge_bundles(ctx, strict, config, bundles, use_parent, outdir, transform, d
     - perform a diff check against the source bundle and the transformed bundle
         (BUNDLEUTILS_MERGE_TRANSFORM_DIFFCHECK_SOURCE_DIR needed for this)
     """
-    set_logging(ctx)
+    set_logging()
 
     config = null_check(config, MERGE_CONFIG_ARG, BUNDLEUTILS_MERGE_CONFIG, False, '')
     bundles = null_check(bundles, BUNDLES_ARG, BUNDLEUTILS_MERGE_BUNDLES, False, '')
@@ -1057,7 +1061,7 @@ def announce(string):
 @click.pass_context
 def ci_validate(ctx, ci_version, ci_type, ci_server_home, source_dir, ignore_warnings, external_rbac):
     """Validate bundle against controller started with ci-start."""
-    set_logging(ctx)
+    set_logging()
     ci_version, ci_type, ci_server_home = server_options_null_check(ci_version, ci_type, ci_server_home)
     source_dir = null_check(source_dir, SOURCE_DIR_ARG, BUNDLEUTILS_VALIDATE_SOURCE_DIR)
     if not os.path.exists(source_dir):
@@ -1075,7 +1079,7 @@ def ci_validate(ctx, ci_version, ci_type, ci_server_home, source_dir, ignore_war
 @click.pass_context
 def ci_sanitize_plugins(ctx, ci_version, ci_type, ci_server_home, source_dir, pin_plugins, custom_url):
     """Sanitizes plugins (needs ci-start)."""
-    set_logging(ctx)
+    set_logging()
     ci_version, ci_type, ci_server_home = server_options_null_check(ci_version, ci_type, ci_server_home)
     source_dir = null_check(source_dir, SOURCE_DIR_ARG, BUNDLEUTILS_TRANSFORM_TARGET_DIR)
     if not os.path.exists(source_dir):
@@ -1151,7 +1155,7 @@ def ci_sanitize_plugins(ctx, ci_version, ci_type, ci_server_home, source_dir, pi
 @click.pass_context
 def ci_start(ctx, ci_version, ci_type, ci_server_home, ci_max_start_time):
     """Start CloudBees Server"""
-    set_logging(ctx)
+    set_logging()
     ci_version, ci_type, ci_server_home = server_options_null_check(ci_version, ci_type, ci_server_home)
     jenkins_manager = JenkinsServerManager(ci_type, ci_version, ci_server_home)
     jenkins_manager.start_server(ci_max_start_time)
@@ -1161,7 +1165,7 @@ def ci_start(ctx, ci_version, ci_type, ci_server_home, ci_max_start_time):
 @click.pass_context
 def ci_stop(ctx, ci_version, ci_type, ci_server_home):
     """Stop CloudBees Server"""
-    set_logging(ctx)
+    set_logging()
     ci_version, ci_type, ci_server_home = server_options_null_check(ci_version, ci_type, ci_server_home)
     jenkins_manager = JenkinsServerManager(ci_type, ci_version, ci_server_home)
     jenkins_manager.stop_server()
@@ -1268,7 +1272,7 @@ def config(ctx, key):
     # if key disable logging
     if key:
         logging.getLogger().setLevel(logging.ERROR)
-    set_logging(ctx)
+    set_logging()
     if key:
         # check if the key starts with BUNDLEUTILS_
         if not key.startswith('BUNDLEUTILS_'):
@@ -1392,7 +1396,7 @@ def find_bundle_by_url(ctx, url, ci_version, bundles_dir):
 
     Use -v '.*' to match any version.
     """
-    set_logging(ctx)
+    set_logging()
     if not ctx.obj.get(BUNDLE_PROFILES, ''):  # if no bundle profiles are found, exit
         logging.error("No bundle profiles found. Exiting.")
         return
@@ -1476,7 +1480,7 @@ def null_check(ctx, obj, obj_name, obj_env_var=None, mandatory=True, default='')
 @click.pass_context
 def validate(ctx, url, username, password, source_dir, ignore_warnings, external_rbac):
     """Validate bundle in source dir against URL."""
-    set_logging(ctx)
+    set_logging()
     _validate(url, username, password, source_dir, ignore_warnings, external_rbac)
 
 def _validate(url, username, password, source_dir, ignore_warnings, external_rbac):
@@ -1602,7 +1606,7 @@ def fetch_options_null_check(ctx, url, path, username, password, target_dir, key
 @click.pass_context
 def fetch(ctx, url, path, username, password, target_dir, keys_to_scalars, plugin_json_path, plugins_json_list_strategy, plugins_json_merge_strategy, catalog_warnings_strategy, offline, ignore_items, cap):
     """Fetch YAML documents from a URL or path."""
-    set_logging(ctx)
+    set_logging()
     update_plugins_options_null_check(plugins_json_list_strategy, plugins_json_merge_strategy, catalog_warnings_strategy, cap)
     fetch_options_null_check(url, path, username, password, target_dir, keys_to_scalars, plugin_json_path, offline, ignore_items)
     try:
@@ -1909,7 +1913,7 @@ def find_plugin_by_id(plugins, plugin_id):
 @click.pass_context
 def update_plugins(ctx, url, path, username, password, target_dir, keys_to_convert, plugin_json_path, plugins_json_list_strategy, plugins_json_merge_strategy, catalog_warnings_strategy, offline, ignore_items, cap):
     """Update plugins in the target directory."""
-    set_logging(ctx)
+    set_logging()
     update_plugins_options_null_check(ctx, plugins_json_list_strategy, plugins_json_merge_strategy, catalog_warnings_strategy, cap)
     fetch_options_null_check(url, path, username, password, target_dir, keys_to_convert, plugin_json_path, offline, ignore_items)
     _update_plugins()
@@ -1924,7 +1928,7 @@ def update_plugins_from_test_server(ctx, ci_type, ci_version, ci_server_home, ta
     """
     Update plugins in the target directory using the plugins from the test server started for validation.
     """
-    set_logging(ctx)
+    set_logging()
     update_plugins_options_null_check(plugins_json_list_strategy, plugins_json_merge_strategy, catalog_warnings_strategy, cap)
     ci_version, ci_type, ci_server_home = server_options_null_check(ci_type, ci_version, ci_server_home)
     target_dir = null_check(target_dir, TARGET_DIR_ARG, BUNDLEUTILS_MERGE_TRANSFORM_TARGET_DIR)
@@ -2222,6 +2226,10 @@ def preprocess_yaml_text(ctx, response_text):
         catalog_warnings_strategy = ctx.obj.get('catalog_warnings_strategy')
         if isinstance(response_text, bytes):
             response_text = response_text.decode('utf-8')
+        # if the response is empty, skip
+        if not response_text:
+            logging.warning('Empty response from server. Skipping.')
+            return response_text
         # find any occurrences of "^--- .*$"
         matching_lines = re.findall(r'^--- .*$', response_text, re.MULTILINE)
         if matching_lines:
@@ -2261,6 +2269,9 @@ def write_all_yaml_docs_from_comments(yaml_docs, target_dir):
         write_yaml_doc(doc, target_dir, filename)
 
 def write_yaml_doc(doc, target_dir, filename):
+    if not doc:
+        logging.warning(f'Skipping empty YAML document')
+        return
     filename = os.path.join(target_dir, filename)
     doc = preprocess_yaml_object(doc)
 
@@ -2639,7 +2650,7 @@ def source_target_prep(source_dir, target_dir, configs, suffix, filename):
 @click.pass_context
 def normalize(ctx, strict, configs, source_dir, target_dir, dry_run):
     """Transform using the normalize.yaml for better comparison."""
-    set_logging(ctx)
+    set_logging()
     source_dir, target_dir, configs = source_target_prep(source_dir, target_dir, configs, '-normalized', 'normalize.yaml')
     _transform(configs, source_dir, target_dir, dry_run)
 
@@ -2661,7 +2672,7 @@ def audit(ctx, strict, configs, source_dir, target_dir, dry_run, hash_seed, no_h
     - Setting BUNDLEUTILS_CREDENTIAL_HASH=false will revert to the standard method.
 
     """
-    set_logging(ctx)
+    set_logging()
 
     source_dir = null_check(source_dir, SOURCE_DIR_ARG, BUNDLEUTILS_AUDIT_SOURCE_DIR)
     target_dir = null_check(target_dir, TARGET_DIR_ARG, BUNDLEUTILS_AUDIT_TARGET_DIR)
@@ -2686,7 +2697,7 @@ def audit(ctx, strict, configs, source_dir, target_dir, dry_run, hash_seed, no_h
 @click.pass_context
 def transform(ctx, strict, configs, source_dir, target_dir, dry_run):
     """Transform using a custom transformation config."""
-    set_logging(ctx)
+    set_logging()
     source_dir = null_check(source_dir, SOURCE_DIR_ARG, BUNDLEUTILS_TRANSFORM_SOURCE_DIR)
     source_dir = os.path.normpath(source_dir)
     target_dir = null_check(target_dir, TARGET_DIR_ARG, BUNDLEUTILS_TRANSFORM_TARGET_DIR)
@@ -2850,7 +2861,7 @@ def update_bundle(ctx, target_dir, description, output_sorted, empty_bundle_stra
     - 'noop': Create a noop jenkins.yaml and continue
 
     """
-    set_logging(ctx)
+    set_logging()
     if recursive:
         if not target_dir:
             target_dir = ctx.obj.get(ORIGINAL_CWD)

--- a/docs/5min_challenge_auditing.md
+++ b/docs/5min_challenge_auditing.md
@@ -10,6 +10,8 @@ This tutorial will explain have your controller audited in 5 mins.
 - [Bonus Exercise #1: using `BUNDLEUTILS_CREDENTIAL_HASH`](#bonus-exercise-1-using-bundleutils_credential_hash)
 - [Bonus Exercise #2: using a custom `normalize.yaml`](#bonus-exercise-2-using-a-custom-normalizeyaml)
 - [Bonus Exercise #3: avoid downloading expensive `items.yaml`](#bonus-exercise-3-avoid-downloading-expensive-itemsyaml)
+- [Bonus Exercise #4: version based bundles](#bonus-exercise-4-version-based-bundles)
+- [Bonus Exercise #5: version based bundles (and preserving git history)](#bonus-exercise-5-version-based-bundles-and-preserving-git-history)
 - [Running in Production](#running-in-production)
   - [Pipeline Job](#pipeline-job)
   - [Operation Center](#operation-center)
@@ -214,10 +216,10 @@ INFO:root:Read YAML from url: http://35.227.58.163.nip.io/default-controller/cor
 ...
 1,83s user 0,04s system 16% cpu 11,317 total    # <-- 11 seconds
 
-❯ find target/docs
+❯ find target/docs                              # <-- contains items.yaml
 target/docs
 target/docs/rbac.yaml
-target/docs/items.yaml                          # <-- items downloaded
+target/docs/items.yaml
 target/docs/plugins.yaml
 target/docs/plugin-catalog.yaml
 target/docs/bundle.yaml
@@ -240,6 +242,160 @@ target/docs/plugins.yaml
 target/docs/plugin-catalog.yaml
 target/docs/bundle.yaml
 target/docs/jenkins.yaml
+```
+
+## Bonus Exercise #4: version based bundles
+
+It might be useful to track the CI versions on bundles when performing audits.
+
+- The controller with the name `team-mobility` would normally result in a bundle of the same name.
+- Wouldn't it be nice if the bundle was called `team-mobility-2.492.3.5` instead?
+- This way, changes within a particular version could be tracked more easily.
+
+This is where the `BUNDLEUTILS_AUTO_ENV_APPEND_VERSION` comes in.
+
+Up until now, we have simple bundle names. E.g.
+
+```sh
+bundle-user@66df4d9bcd27:/opt/bundleutils/work/audits$ git ls-files
+.gitignore
+team-mobility/bundle.yaml
+team-mobility/items.yaml
+team-mobility/jenkins.yaml
+team-mobility/plugins.yaml
+```
+
+Let us use version based bundle names:
+
+```sh
+export BUNDLEUTILS_AUTO_ENV_APPEND_VERSION=true
+```
+
+And perform the audit again.
+
+```sh
+bundle-user@66df4d9bcd27:/opt/bundleutils/work/audits$ ../examples/tutorials/auditing/audit.sh
+...
+...
+AUDITING: Committing changes to team-mobility-2.479.3.1
+[main fda2da8] Audit bundle team-mobility-2.479.3.1 (version: 2.479.3.1)
+ 4 files changed, 1053 insertions(+)
+ create mode 100644 team-mobility-2.479.3.1/bundle.yaml
+ create mode 100644 team-mobility-2.479.3.1/items.yaml
+ create mode 100644 team-mobility-2.479.3.1/jenkins.yaml
+ create mode 100644 team-mobility-2.479.3.1/plugins.yaml
+AUDITING: Commit: YOUR_GIT_REPO/commit/fda2da8 Audit bundle team-mobility-2.479.3.1 (version: 2.479.3.1)
+AUDITING: Bundle audit complete.
+```
+
+Now the bundle has the version appended to the name:
+
+```sh
+bundle-user@66df4d9bcd27:/opt/bundleutils/work/audits$ git ls-files
+.gitignore
+team-mobility-2.479.3.1/bundle.yaml
+team-mobility-2.479.3.1/items.yaml
+team-mobility-2.479.3.1/jenkins.yaml
+team-mobility-2.479.3.1/plugins.yaml
+team-mobility/bundle.yaml
+team-mobility/items.yaml
+team-mobility/jenkins.yaml
+team-mobility/plugins.yaml
+```
+
+## Bonus Exercise #5: version based bundles (and preserving git history)
+
+**NOTE:** you must have completed [Bonus Exercise #4: version based bundles](#bonus-exercise-4-version-based-bundles) before doing this exercise.
+
+Following on from the version based bundles example, you may want to:
+
+- Have version based bundles for visibilities sake
+- But still preserve the git history on individual files.
+
+Enter the mandatory variable `GIT_BUNDLE_PRESERVE_HISTORY`.
+
+The [../examples/tutorials/auditing/audit.sh](../examples/tutorials/auditing/audit.sh) file needs to know what to do when:
+
+- a new version is detected
+- a previous version exists
+
+> Should the git history of the previous version be preserved in the new version, or should we add the files and start a new git history?
+
+If not set at all, the script will fail.
+
+Setting `export GIT_BUNDLE_PRESERVE_HISTORY=false` will:
+
+- add a new/fresh directory for the new version
+- commit the changes
+- the previous versions directory will retain its own git history
+- the new versions directory will have a no previous git history
+
+Setting `export GIT_BUNDLE_PRESERVE_HISTORY=true` will:
+
+- rename the previous versions directory to the new versions directory
+- commit the changes (thus preserving the git history)
+- add a new/fresh directory previous version with the last known configuration
+- commit the changes
+
+**Let's try this in our example:**
+
+Preparation: Normally, this will happen organically when upgrading controllers. However, for the challenge, we will just immitate having a previous version installed.
+
+- set your current version - enter: `MY_CURRENT_VERSION=team-mobility-2.479.3.1`
+- and a 'pretend' earlier version - enter: `MY_PREVIOUS_VERSION=team-mobility-2.479.3.0`.
+
+Now run:
+
+```sh
+{
+  git mv "$MY_CURRENT_VERSION" "$MY_PREVIOUS_VERSION"
+  git commit -m "We are just pretending this is an earlier version" "$MY_CURRENT_VERSION" "$MY_PREVIOUS_VERSION"
+  git ls-files
+}
+```
+
+Now the 'previous' version is in place, let's set the environment variable to preserve the git history.
+
+```sh
+export GIT_BUNDLE_PRESERVE_HISTORY=true
+```
+
+And perform the audit again:
+
+```sh
+../examples/tutorials/auditing/audit.sh
+```
+
+You will see something like:
+
+```sh
+bundle-user@66df4d9bcd27:/opt/bundleutils/work/audits$ ../examples/tutorials/auditing/audit.sh
+...
+...
+AUDITING: Bundle team-mobility-2.479.3.1 not found. Looking for a previous version...
+AUDITING: Migrating from previous version team-mobility-2.479.3.0 to team-mobility-2.479.3.1
+[main 40ee945] Renaming team-mobility-2.479.3.0 to team-mobility-2.479.3.1 to preserve the git history
+ 4 files changed, 0 insertions(+), 0 deletions(-)
+ rename {team-mobility-2.479.3.0 => team-mobility-2.479.3.1}/bundle.yaml (100%)
+ rename {team-mobility-2.479.3.0 => team-mobility-2.479.3.1}/items.yaml (100%)
+ rename {team-mobility-2.479.3.0 => team-mobility-2.479.3.1}/jenkins.yaml (100%)
+ rename {team-mobility-2.479.3.0 => team-mobility-2.479.3.1}/plugins.yaml (100%)
+[main aa9b096] Last known state of team-mobility-2.479.3.0 before moving to team-mobility-2.479.3.1
+ 5 files changed, 1055 insertions(+)
+ create mode 100644 .gitignore
+ create mode 100644 team-mobility-2.479.3.0/bundle.yaml
+ create mode 100644 team-mobility-2.479.3.0/items.yaml
+ create mode 100644 team-mobility-2.479.3.0/jenkins.yaml
+ create mode 100644 team-mobility-2.479.3.0/plugins.yaml
+```
+
+The git history of the 'new' version is a continuation of the old...
+
+```sh
+bundle-user@66df4d9bcd27:/opt/bundleutils/work/audits$ git log --oneline team-mobility-2.479.3.1
+40ee945 Renaming team-mobility-2.479.3.0 to team-mobility-2.479.3.1 to preserve the git history
+380be9e We are just pretending this is an earlier version
+fda2da8 Audit bundle team-mobility-2.479.3.1 (version: 2.479.3.1)
 ```
 
 ## Running in Production

--- a/docs/5min_challenge_auditing.md
+++ b/docs/5min_challenge_auditing.md
@@ -198,6 +198,15 @@ AUDITING: Commit: YOUR_GIT_REPO/commit/a5e4b17 Audit bundle cjoc
 AUDITING: Bundle audit complete.
 ```
 
+Revert by removing the custom file:
+
+```sh
+{
+  rm normalize.yaml
+  ../examples/tutorials/auditing/audit.sh
+}
+```
+
 ## Bonus Exercise #3: avoid downloading expensive `items.yaml`
 
 Sometimes it is not required to include the items in the bundle, e.g.
@@ -207,11 +216,33 @@ Sometimes it is not required to include the items in the bundle, e.g.
 
 In this case, either add the `--ignore-items` option to the fetch command, or set `export BUNDLEUTILS_FETCH_IGNORE_ITEMS=true` environment variable.
 
+Let's try it out in our example:
+
+```sh
+{
+  export BUNDLEUTILS_FETCH_IGNORE_ITEMS=true
+  ../examples/tutorials/auditing/audit.sh
+  git show --stat
+}
+```
+
+And revert our changes (re-adding the items):
+
+```sh
+{
+  export BUNDLEUTILS_FETCH_IGNORE_ITEMS=false
+  ../examples/tutorials/auditing/audit.sh
+  git show --stat
+}
+```
+
+So, just to recap:
+
 **Using...** `export BUNDLEUTILS_FETCH_IGNORE_ITEMS=false`
 
 ```sh
 ❯ time BUNDLEUTILS_FETCH_IGNORE_ITEMS=false bundleutils fetch
-INFO:root:Read YAML from url: http://35.227.58.163.nip.io/default-controller/core-casc-export
+INFO:root:Read YAML from url: http://ci.acme.org/default-controller/core-casc-export
 ...
 ...
 1,83s user 0,04s system 16% cpu 11,317 total    # <-- 11 seconds
@@ -268,10 +299,14 @@ team-mobility/plugins.yaml
 Let us use version based bundle names:
 
 ```sh
-export BUNDLEUTILS_AUTO_ENV_APPEND_VERSION=true
+{
+  export BUNDLEUTILS_AUTO_ENV_APPEND_VERSION=true
+  ../examples/tutorials/auditing/audit.sh
+  git show --stat
+}
 ```
 
-And perform the audit again.
+Performing the audit again appends the version to the bundle:
 
 ```sh
 bundle-user@66df4d9bcd27:/opt/bundleutils/work/audits$ ../examples/tutorials/auditing/audit.sh
@@ -288,7 +323,7 @@ AUDITING: Commit: YOUR_GIT_REPO/commit/fda2da8 Audit bundle team-mobility-2.479.
 AUDITING: Bundle audit complete.
 ```
 
-Now the bundle has the version appended to the name:
+List the files to see:
 
 ```sh
 bundle-user@66df4d9bcd27:/opt/bundleutils/work/audits$ git ls-files
@@ -309,8 +344,8 @@ team-mobility/plugins.yaml
 
 Following on from the version based bundles example, you may want to:
 
-- Have version based bundles for visibilities sake
-- But still preserve the git history on individual files.
+- Have version based bundles for the sake of transparency
+- Still preserve the git history on individual directories
 
 Enter the mandatory variable `GIT_BUNDLE_PRESERVE_HISTORY`.
 
@@ -321,16 +356,16 @@ The [../examples/tutorials/auditing/audit.sh](../examples/tutorials/auditing/aud
 
 > Should the git history of the previous version be preserved in the new version, or should we add the files and start a new git history?
 
-If not set at all, the script will fail.
+**NONE:** If not set at all, the script will fail.
 
-Setting `export GIT_BUNDLE_PRESERVE_HISTORY=false` will:
+**FALSE:** Setting `export GIT_BUNDLE_PRESERVE_HISTORY=false` will:
 
 - add a new/fresh directory for the new version
 - commit the changes
 - the previous versions directory will retain its own git history
 - the new versions directory will have a no previous git history
 
-Setting `export GIT_BUNDLE_PRESERVE_HISTORY=true` will:
+**TRUE:** Setting `export GIT_BUNDLE_PRESERVE_HISTORY=true` will:
 
 - rename the previous versions directory to the new versions directory
 - commit the changes (thus preserving the git history)
@@ -387,6 +422,8 @@ AUDITING: Migrating from previous version team-mobility-2.479.3.0 to team-mobili
  create mode 100644 team-mobility-2.479.3.0/items.yaml
  create mode 100644 team-mobility-2.479.3.0/jenkins.yaml
  create mode 100644 team-mobility-2.479.3.0/plugins.yaml
+...
+...
 ```
 
 The git history of the 'new' version is a continuation of the old...


### PR DESCRIPTION
This PR adds the first set of options to simplify, and eventually deprecate, the `bundle-profiles.yaml` approach.

The idea will be to:

- determine all necessary values from the provided URL alone
- follow the rules of convention over configuration
- provide sensible defaults which can easily be overridden if needed

In the PR:

- Add new bonus exercises to auditing 5 minute challenge 
- Fixes after running through the entire 5 minute challenge
