### PR TITLE
Challenge review and cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     less \
     vim \
     git \
+    jq \
     make \
     skopeo \
     python3 \

--- a/bundleutilspkg/src/bundleutilspkg/bundleutils.py
+++ b/bundleutilspkg/src/bundleutilspkg/bundleutils.py
@@ -486,6 +486,7 @@ def _check_url_and_determine_env_vars(ctx):
     if not url:
         die(f'No URL found in environment variables or command line arguments')
     instance_name = _extract_name_from_url(url)
+    ci_type = lookup_type_from_url(url, '')
 
     bundle_name = instance_name
     last_known_bundle_name = ''
@@ -511,6 +512,7 @@ def _check_url_and_determine_env_vars(ctx):
     _set_env_if_not_set('AUTOSET', BUNDLEUTILS_INSTANCE_NAME, instance_name)
     _set_env_if_not_set('AUTOSET', BUNDLEUTILS_BUNDLE_NAME, bundle_name)
     _set_env_if_not_set('AUTOSET', BUNDLEUTILS_CI_VERSION, version)
+    _set_env_if_not_set('AUTOSET', BUNDLEUTILS_CI_TYPE, ci_type)
     _set_env_if_not_set('AUTOSET', BUNDLEUTILS_FETCH_TARGET_DIR, f'target/fetched/{bundle_name}')
     _set_env_if_not_set('AUTOSET', BUNDLEUTILS_TRANSFORM_SOURCE_DIR, os.environ.get(BUNDLEUTILS_FETCH_TARGET_DIR))
     _set_env_if_not_set('AUTOSET', BUNDLEUTILS_TRANSFORM_TARGET_DIR, bundle_target_dir)
@@ -583,6 +585,42 @@ def compare_func(x, y, level=None):
         return x['id'] == y['id']
     except Exception:
         raise CannotCompare() from None
+
+def lookup_type_from_url(url, ci_type, default_ci_type = ''):
+    ci_type = null_check(ci_type, CI_TYPE_ARG, BUNDLEUTILS_CI_TYPE, False, default_ci_type)
+    if not ci_type:
+        logging.debug(f'No type found in environment variables or command line arguments. Using whoami to determine the type')
+        whoami_url = f'{url}/whoAmI'
+        try:
+            response = requests.get(whoami_url, timeout=5)
+            if response.status_code == 200:
+                # grep -oE "CloudBees CI (Managed Controller|Client Controller|Cloud Operations Center|Operations Center) [0-9.-]+-rolling"
+                response_text = response.text
+                # find the first match
+                match = re.search(r'CloudBees CI (Managed Controller|Client Controller|Cloud Operations Center|Operations Center) [0-9.-]+-rolling', response_text)
+                if match:
+                    ci_type = match.group(1)
+                    # case switch the ci_type
+                    if ci_type == 'Managed Controller':
+                        ci_type = 'mm'
+                    elif ci_type == 'Client Controller':
+                        ci_type = 'cm'
+                    elif ci_type == 'Cloud Operations Center':
+                        ci_type = 'oc'
+                    elif ci_type == 'Operations Center':
+                        ci_type = 'oc-traditional'
+                    else:
+                        die(f'Unknown CI type: {ci_type}')
+                    logging.debug(f"Type: {ci_type} (taken from remote)")
+                logging.debug(f"Version: {ci_type} (taken from remote)")
+            else:
+                die(f"Trying to get version from URL {url} - returned a non-OK status code: {response.status_code}")
+        except requests.exceptions.RequestException as e:
+            die(f"Trying to get CI version from URL {url} - not reachable. Reason: {e}")
+    else:
+        logging.debug(f"Version: {ci_type} (taken from command line or env)")
+    return ci_type
+
 
 def lookup_url_and_version(url, ci_version, default_url = '', default_ci_version = ''):
     url = lookup_url(url, default_url)
@@ -1843,9 +1881,10 @@ def _analyze_server_plugins(ctx, plugins_from_json, plugins_json_list_strategy, 
             logging.info(f"{BUNDLEUTILS_FETCH_USE_CAP_ENVELOPE} option detected. Removing CAP plugin dependencies...")
             expected_plugins_copy = expected_plugins.copy()
             url, ci_version = lookup_url_and_version(url, '')
+            ci_type = lookup_type_from_url(url, '')
             if not url:
                 die("No URL provided for CAP plugin removal")
-            ci_version, ci_type, ci_server_home = server_options_null_check(ci_version, '', '')
+            ci_version, ci_type, ci_server_home = server_options_null_check(ci_version, ci_type, '')
             jenkins_manager = JenkinsServerManager(ci_type, ci_version, ci_server_home)
             envelope_json = jenkins_manager.get_envelope_json_from_war()
             envelope_json = json.loads(envelope_json)

--- a/bundleutilspkg/src/bundleutilspkg/bundleutils.py
+++ b/bundleutilspkg/src/bundleutilspkg/bundleutils.py
@@ -612,13 +612,14 @@ def lookup_type_from_url(url, ci_type, default_ci_type = ''):
                     else:
                         die(f'Unknown CI type: {ci_type}')
                     logging.debug(f"Type: {ci_type} (taken from remote)")
-                logging.debug(f"Version: {ci_type} (taken from remote)")
+                else:
+                    die(f'Could not determine CI type from URL {url} - no match found')
             else:
-                die(f"Trying to get version from URL {url} - returned a non-OK status code: {response.status_code}")
+                die(f"Trying to get type from URL {url} - returned a non-OK status code: {response.status_code}")
         except requests.exceptions.RequestException as e:
-            die(f"Trying to get CI version from URL {url} - not reachable. Reason: {e}")
+            die(f"Trying to get CI type from URL {url} - not reachable. Reason: {e}")
     else:
-        logging.debug(f"Version: {ci_type} (taken from command line or env)")
+        logging.debug(f"Type: {ci_type} (taken from command line or env)")
     return ci_type
 
 

--- a/docs/5min_challenge_auditing.md
+++ b/docs/5min_challenge_auditing.md
@@ -13,6 +13,7 @@ This tutorial will explain how to have your controller audited in 5 mins.
 - [Bonus Exercise #3: avoid downloading expensive `items.yaml`](#bonus-exercise-3-avoid-downloading-expensive-itemsyaml)
 - [Bonus Exercise #4: version based bundles](#bonus-exercise-4-version-based-bundles)
 - [Bonus Exercise #5: version based bundles (and preserving git history)](#bonus-exercise-5-version-based-bundles-and-preserving-git-history)
+- [Bonus Exercise #6: all in one](#bonus-exercise-6-all-in-one)
 - [Running in Production](#running-in-production)
   - [Pipeline Job](#pipeline-job)
   - [Operation Center](#operation-center)
@@ -493,6 +494,41 @@ bundle-user@66df4d9bcd27:/opt/bundleutils/work/audits$ git log --oneline team-mo
 40ee945 Renaming team-mobility-2.479.3.0 to team-mobility-2.479.3.1 to preserve the git history
 380be9e We are just pretending this is an earlier version
 fda2da8 Audit bundle team-mobility-2.479.3.1 (version: 2.479.3.1)
+```
+
+## Bonus Exercise #6: all in one
+
+The `audit.sh` has a special feature which, given an operation center URL, will:
+
+- find all ONLINE controllers
+- perform an audit on each
+- perform a final audit on the operation center
+
+```sh
+bundle-user@b7df010ce271:/opt/bundleutils/work/audits$ ../examples/tutorials/auditing/audit.sh cjoc-and-online-controllers
+...
+...
+AUDITING: Auditing online controllers and then the OC:
+https://ci.acme.org/audited-1/
+https://ci.acme.org/audited-2/
+...
+...
+INFO:root:Read YAML from url: https://ci.acme.org/audited-1//core-casc-export
+...
+...
+INFO:root:Read YAML from url: https://ci.acme.org/audited-2//core-casc-export
+...
+...
+INFO:root:Read YAML from url: https://ci.acme.org/cjoc//core-casc-export
+```
+
+The resulting commits:
+
+```sh
+bundle-user@b7df010ce271:/opt/bundleutils/work/audits$ git log --oneline
+0696183 (HEAD -> main) Audit bundle cjoc (version: 2.492.2.3)
+8881562 Audit bundle audited-2 (version: 2.492.2.3)
+380be9e Audit bundle audited-1 (version: 2.492.2.3)
 ```
 
 ## Running in Production

--- a/docs/5min_challenge_auditing.md
+++ b/docs/5min_challenge_auditing.md
@@ -1,11 +1,12 @@
 # 5 Minute Challenge: Auditing
 
-This tutorial will explain have your controller audited in 5 mins.
+This tutorial will explain to have your controller audited in 5 mins.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Prerequisites](#prerequisites)
+  - [Minimum Required Permissions](#minimum-required-permissions)
 - [3, 2, 1...Go](#3-2-1go)
 - [Bonus Exercise #1: using `BUNDLEUTILS_CREDENTIAL_HASH`](#bonus-exercise-1-using-bundleutils_credential_hash)
 - [Bonus Exercise #2: using a custom `normalize.yaml`](#bonus-exercise-2-using-a-custom-normalizeyaml)
@@ -21,7 +22,28 @@ This tutorial will explain have your controller audited in 5 mins.
 ## Prerequisites
 
 - One or more target URL's (controller or operations center)
-- A valid username and corresponding API token
+- A valid username and corresponding API token, referenced below
+  - `BUNDLEUTILS_USERNAME`
+  - `BUNDLEUTILS_PASSWORD`
+
+### Minimum Required Permissions
+
+The minimum set of permissions needed for the user are as follows:
+
+```yaml
+removeStrategy:
+  rbac: SYNC
+roles:
+- permissions:
+  - hudson.model.Hudson.SystemRead
+  - com.cloudbees.jenkins.plugins.casc.permissions.CascPermission.Item
+  - com.cloudbees.jenkins.plugins.casc.permissions.CascPermission.Administer
+  name: validate-casc
+```
+
+Whereby the `hudson.model.Hudson.SystemRead` can be enabled using a system property, see [Enable the optional Overall/SystemRead permission](https://www.jenkins.io/doc/book/managing/system-properties/#jenkins-security-systemreadpermission).
+
+**NOTE:** If you do not have the SystemRead available, `hudson.model.Hudson.Administer` will be needed.
 
 ## 3, 2, 1...Go
 
@@ -82,7 +104,7 @@ git show --stat
 > [!NOTE]
 > 4 minutes...
 
-Make a change to your target controller the `audit.sh` after making a change:
+Make a change to your target controller and run the `audit.sh` again:
 
 ```sh
 ../examples/tutorials/auditing/audit.sh

--- a/examples/tutorials/auditing/audit.sh
+++ b/examples/tutorials/auditing/audit.sh
@@ -32,8 +32,31 @@ source_env
 if [[ "${1:-}" == "help" ]]; then
   echo -e "$usage_message"
   exit 0
-elif [[ "${1:-}" == http* ]]; then
-  export JENKINS_URL="${1:-}"
+elif [[ "${1:-}" == "cjoc-and-online-controllers" ]]; then
+  # List all controllers
+  CONTROLLERS_JSON=$(curl --fail -u "$BUNDLEUTILS_USERNAME:$BUNDLEUTILS_PASSWORD" "${JENKINS_URL}/api/json?pretty&tree=jobs\[name,online,state,endpoint\]")
+  ONLINE_CONTROLERS=$(echo "$CONTROLLERS_JSON" | jq -r '.jobs[]|select(.online == true).endpoint')
+  if [[ -z "$ONLINE_CONTROLERS" ]]; then
+    echo "AUDITING: No online controllers found."
+    exit 0
+  else
+    echo
+    echo
+    echo "AUDITING: Auditing the following ONLINE controllers and then the OC:"
+    echo "$ONLINE_CONTROLERS"
+    echo
+    echo
+    sleep 5
+  fi
+  for CONTROLLER in $ONLINE_CONTROLERS; do
+    echo "AUDITING: Found online controller: $CONTROLLER"
+    # Fetch the bundle from the controller
+    if BUNDLEUTILS_JENKINS_URL="$CONTROLLER" $0; then
+      echo "AUDITING: Bundle fetched from $CONTROLLER"
+    else
+      echo "AUDITING: Failed to fetch bundle from $CONTROLLER"
+    fi
+  done
 elif [[ "${1:-}" == "setup" ]]; then
   if [[ ! -t 0 ]]; then
     echo "AUDITING: Error: Setup requires a terminal to run."

--- a/examples/tutorials/auditing/audit.sh
+++ b/examples/tutorials/auditing/audit.sh
@@ -35,20 +35,20 @@ if [[ "${1:-}" == "help" ]]; then
 elif [[ "${1:-}" == "cjoc-and-online-controllers" ]]; then
   # List all controllers
   CONTROLLERS_JSON=$(curl --fail -u "$BUNDLEUTILS_USERNAME:$BUNDLEUTILS_PASSWORD" "${JENKINS_URL}/api/json?pretty&tree=jobs\[name,online,state,endpoint\]")
-  ONLINE_CONTROLERS=$(echo "$CONTROLLERS_JSON" | jq -r '.jobs[]|select(.online == true).endpoint')
-  if [[ -z "$ONLINE_CONTROLERS" ]]; then
+  ONLINE_CONTROLLERS=$(echo "$CONTROLLERS_JSON" | jq -r '.jobs[]|select(.online == true).endpoint')
+  if [[ -z "$ONLINE_CONTROLLERS" ]]; then
     echo "AUDITING: No online controllers found."
     exit 0
   else
     echo
     echo
     echo "AUDITING: Auditing the following ONLINE controllers and then the OC:"
-    echo "$ONLINE_CONTROLERS"
+    echo "$ONLINE_CONTROLLERS"
     echo
     echo
     sleep 5
   fi
-  for CONTROLLER in $ONLINE_CONTROLERS; do
+  for CONTROLLER in $ONLINE_CONTROLLERS; do
     echo "AUDITING: Found online controller: $CONTROLLER"
     # Fetch the bundle from the controller
     if BUNDLEUTILS_JENKINS_URL="$CONTROLLER" $0; then


### PR DESCRIPTION
This PR addresses issue https://github.com/tsmp-falcon-platform/ci-bundle-utils/issues/98 by cleaning up the code and adding a new feature to test operations center and all online controllers, while also improving documentation for permissions.

- Enhanced the audit script in tutorials to support the "cjoc-and-online-controllers" use-case.
- Updated documentation to include minimum required permissions and a new bonus exercise.
- Added URL type detection improvements in the bundleutils module and installed jq in the Dockerfile.