### PR TITLE
Move patches to in-memory operations

### DIFF
--- a/bundleutilspkg/tests/resources/performance/lots-of-script-hashes-expected/items.yaml
+++ b/bundleutilspkg/tests/resources/performance/lots-of-script-hashes-expected/items.yaml
@@ -20477,4 +20477,3 @@ items:
           name: BUNDLEUTILS_BOOTSTRAP_PROFILE
           description: Bootstrap profile to use
   resumeBlocked: false
-

--- a/bundleutilspkg/tests/resources/performance/lots-of-script-hashes-expected/jenkins.yaml
+++ b/bundleutilspkg/tests/resources/performance/lots-of-script-hashes-expected/jenkins.yaml
@@ -1,3 +1,462 @@
+credentials:
+  system:
+    domainCredentials:
+    - credentials:
+      - basicSSHUserPrivateKey:
+          description: |-
+            jenkins-centos7-static-agent
+          id: jenkins-centos7-static-agent
+          privateKeySource:
+            directEntry:
+              privateKey: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: jenkins
+      - basicSSHUserPrivateKey:
+          description: |-
+            windows2012
+          id: windows2012
+          privateKeySource:
+            directEntry:
+              privateKey: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman
+      - basicSSHUserPrivateKey:
+          description: |-
+            github-sshkey-misterman1
+          id: github-sshkey-misterman1
+          privateKeySource:
+            directEntry:
+              privateKey: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman1
+      - usernamePassword:
+          description: |-
+            misterman1-githubaccount-accesstoken-api
+          id: misterman1-githubaccount-accesstoken-api
+          password: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman1
+      - string:
+          description: |-
+            Webhook secret for https://github.com/apps/cloudbees-ci-misterman1-casc
+          id: 00428b3c-7e38-4fcd-a520-ddaaa2bd4c17
+          scope: SYSTEM
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - string:
+          description: |-
+            Webhook secret for https://github.com/apps/cloudbees-ci-misterman1-practice
+          id: 11dc6f8e-d68a-4fde-93de-d264a0c019a9
+          scope: SYSTEM
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - string:
+          description: |-
+            gh_pat_secrettest
+          id: gh_pat_secrettest
+          scope: GLOBAL
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - string:
+          description: |-
+            mistermanbb
+          id: mistermanbb
+          scope: GLOBAL
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - usernamePassword:
+          description: |-
+            bbactoken
+          id: bbactoken
+          password: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman@cloudbees.com
+      - string:
+          description: |-
+            jmrepokey
+          id: jmrepokey
+          scope: GLOBAL
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - usernamePassword:
+          description: |-
+            cloudbees-api-token
+          id: cloudbees-api-token
+          password: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman
+      - string:
+          description: |-
+            zach_ken_admin
+          id: zach_ken_admin
+          scope: GLOBAL
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - file:
+          description: |-
+            values-dev-deleteme
+          fileName: values-dev.yaml
+          id: values-dev-deleteme
+          scope: GLOBAL
+          secretBytes: bu-hash-056cedb4a44c8e9d41823e2d
+      - basicSSHUserPrivateKey:
+          description: |-
+            jenkins-centos7-static-agent
+          id: a1jenkins-centos7-static-agent
+          privateKeySource:
+            directEntry:
+              privateKey: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: jenkins
+      - basicSSHUserPrivateKey:
+          description: |-
+            windows2012
+          id: a1windows2012
+          privateKeySource:
+            directEntry:
+              privateKey: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman
+      - basicSSHUserPrivateKey:
+          description: |-
+            github-sshkey-misterman1
+          id: a1github-sshkey-misterman1
+          privateKeySource:
+            directEntry:
+              privateKey: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman1
+      - usernamePassword:
+          description: |-
+            misterman1-githubaccount-accesstoken-api
+          id: a1misterman1-githubaccount-accesstoken-api
+          password: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman1
+      - string:
+          description: |-
+            Webhook secret for https://github.com/apps/cloudbees-ci-misterman1-casc
+          id: a100428b3c-7e38-4fcd-a520-ddaaa2bd4c17
+          scope: SYSTEM
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - string:
+          description: |-
+            Webhook secret for https://github.com/apps/cloudbees-ci-misterman1-practice
+          id: a111dc6f8e-d68a-4fde-93de-d264a0c019a9
+          scope: SYSTEM
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - string:
+          description: |-
+            gh_pat_secrettest
+          id: a1gh_pat_secrettest
+          scope: GLOBAL
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - string:
+          description: |-
+            mistermanbb
+          id: a1mistermanbb
+          scope: GLOBAL
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - usernamePassword:
+          description: |-
+            bbactoken
+          id: a1bbactoken
+          password: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman@cloudbees.com
+      - string:
+          description: |-
+            jmrepokey
+          id: a1jmrepokey
+          scope: GLOBAL
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - usernamePassword:
+          description: |-
+            cloudbees-api-token
+          id: a1cloudbees-api-token
+          password: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman
+      - string:
+          description: |-
+            zach_ken_admin
+          id: a1zach_ken_admin
+          scope: GLOBAL
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - file:
+          description: |-
+            values-dev-deleteme
+          fileName: values-dev.yaml
+          id: a1values-dev-deleteme
+          scope: GLOBAL
+          secretBytes: bu-hash-056cedb4a44c8e9d41823e2d
+      - basicSSHUserPrivateKey:
+          description: |-
+            jenkins-centos7-static-agent
+          id: a2jenkins-centos7-static-agent
+          privateKeySource:
+            directEntry:
+              privateKey: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: jenkins
+      - basicSSHUserPrivateKey:
+          description: |-
+            windows2012
+          id: a2windows2012
+          privateKeySource:
+            directEntry:
+              privateKey: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman
+      - basicSSHUserPrivateKey:
+          description: |-
+            github-sshkey-misterman1
+          id: a2github-sshkey-misterman1
+          privateKeySource:
+            directEntry:
+              privateKey: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman1
+      - usernamePassword:
+          description: |-
+            misterman1-githubaccount-accesstoken-api
+          id: a2misterman1-githubaccount-accesstoken-api
+          password: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman1
+      - string:
+          description: |-
+            Webhook secret for https://github.com/apps/cloudbees-ci-misterman1-casc
+          id: a200428b3c-7e38-4fcd-a520-ddaaa2bd4c17
+          scope: SYSTEM
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - string:
+          description: |-
+            Webhook secret for https://github.com/apps/cloudbees-ci-misterman1-practice
+          id: a211dc6f8e-d68a-4fde-93de-d264a0c019a9
+          scope: SYSTEM
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - string:
+          description: |-
+            gh_pat_secrettest
+          id: a2gh_pat_secrettest
+          scope: GLOBAL
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - string:
+          description: |-
+            mistermanbb
+          id: a2mistermanbb
+          scope: GLOBAL
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - usernamePassword:
+          description: |-
+            bbactoken
+          id: a2bbactoken
+          password: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman@cloudbees.com
+      - string:
+          description: |-
+            jmrepokey
+          id: a2jmrepokey
+          scope: GLOBAL
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - usernamePassword:
+          description: |-
+            cloudbees-api-token
+          id: a2cloudbees-api-token
+          password: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman
+      - string:
+          description: |-
+            zach_ken_admin
+          id: a2zach_ken_admin
+          scope: GLOBAL
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - file:
+          description: |-
+            values-dev-deleteme
+          fileName: values-dev.yaml
+          id: a2values-dev-deleteme
+          scope: GLOBAL
+          secretBytes: bu-hash-056cedb4a44c8e9d41823e2d
+      - basicSSHUserPrivateKey:
+          description: |-
+            jenkins-centos7-static-agent
+          id: a3jenkins-centos7-static-agent
+          privateKeySource:
+            directEntry:
+              privateKey: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: jenkins
+      - basicSSHUserPrivateKey:
+          description: |-
+            windows2012
+          id: a3windows2012
+          privateKeySource:
+            directEntry:
+              privateKey: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman
+      - basicSSHUserPrivateKey:
+          description: |-
+            github-sshkey-misterman1
+          id: a3github-sshkey-misterman1
+          privateKeySource:
+            directEntry:
+              privateKey: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman1
+      - usernamePassword:
+          description: |-
+            misterman1-githubaccount-accesstoken-api
+          id: a3misterman1-githubaccount-accesstoken-api
+          password: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman1
+      - string:
+          description: |-
+            Webhook secret for https://github.com/apps/cloudbees-ci-misterman1-casc
+          id: a300428b3c-7e38-4fcd-a520-ddaaa2bd4c17
+          scope: SYSTEM
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - string:
+          description: |-
+            Webhook secret for https://github.com/apps/cloudbees-ci-misterman1-practice
+          id: a311dc6f8e-d68a-4fde-93de-d264a0c019a9
+          scope: SYSTEM
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - string:
+          description: |-
+            gh_pat_secrettest
+          id: a3gh_pat_secrettest
+          scope: GLOBAL
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - string:
+          description: |-
+            mistermanbb
+          id: a3mistermanbb
+          scope: GLOBAL
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - usernamePassword:
+          description: |-
+            bbactoken
+          id: a3bbactoken
+          password: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman@cloudbees.com
+      - string:
+          description: |-
+            jmrepokey
+          id: a3jmrepokey
+          scope: GLOBAL
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - usernamePassword:
+          description: |-
+            cloudbees-api-token
+          id: a3cloudbees-api-token
+          password: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman
+      - string:
+          description: |-
+            zach_ken_admin
+          id: a3zach_ken_admin
+          scope: GLOBAL
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - file:
+          description: |-
+            values-dev-deleteme
+          fileName: values-dev.yaml
+          id: a3values-dev-deleteme
+          scope: GLOBAL
+          secretBytes: bu-hash-056cedb4a44c8e9d41823e2d
+      - basicSSHUserPrivateKey:
+          description: |-
+            jenkins-centos7-static-agent
+          id: a4jenkins-centos7-static-agent
+          privateKeySource:
+            directEntry:
+              privateKey: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: jenkins
+      - basicSSHUserPrivateKey:
+          description: |-
+            windows2012
+          id: a4windows2012
+          privateKeySource:
+            directEntry:
+              privateKey: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman
+      - basicSSHUserPrivateKey:
+          description: |-
+            github-sshkey-misterman1
+          id: a4github-sshkey-misterman1
+          privateKeySource:
+            directEntry:
+              privateKey: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman1
+      - usernamePassword:
+          description: |-
+            misterman1-githubaccount-accesstoken-api
+          id: a4misterman1-githubaccount-accesstoken-api
+          password: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman1
+      - string:
+          description: |-
+            Webhook secret for https://github.com/apps/cloudbees-ci-misterman1-casc
+          id: a400428b3c-7e38-4fcd-a520-ddaaa2bd4c17
+          scope: SYSTEM
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - string:
+          description: |-
+            Webhook secret for https://github.com/apps/cloudbees-ci-misterman1-practice
+          id: a411dc6f8e-d68a-4fde-93de-d264a0c019a9
+          scope: SYSTEM
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - string:
+          description: |-
+            gh_pat_secrettest
+          id: a4gh_pat_secrettest
+          scope: GLOBAL
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - string:
+          description: |-
+            mistermanbb
+          id: a4mistermanbb
+          scope: GLOBAL
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - usernamePassword:
+          description: |-
+            bbactoken
+          id: a4bbactoken
+          password: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman@cloudbees.com
+      - string:
+          description: |-
+            jmrepokey
+          id: a4jmrepokey
+          scope: GLOBAL
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - usernamePassword:
+          description: |-
+            cloudbees-api-token
+          id: a4cloudbees-api-token
+          password: bu-hash-056cedb4a44c8e9d41823e2d
+          scope: GLOBAL
+          username: misterman
+      - string:
+          description: |-
+            zach_ken_admin
+          id: a4zach_ken_admin
+          scope: GLOBAL
+          secret: bu-hash-056cedb4a44c8e9d41823e2d
+      - file:
+          description: |-
+            values-dev-deleteme
+          fileName: values-dev.yaml
+          id: a4values-dev-deleteme
+          scope: GLOBAL
+          secretBytes: bu-hash-056cedb4a44c8e9d41823e2d
 jenkins:
   clouds:
   - operationsCenterAgentProvisioningService

--- a/bundleutilspkg/tests/resources/performance/lots-of-script-hashes/jenkins.yaml
+++ b/bundleutilspkg/tests/resources/performance/lots-of-script-hashes/jenkins.yaml
@@ -1,3 +1,462 @@
+credentials:
+  system:
+    domainCredentials:
+    - credentials:
+      - basicSSHUserPrivateKey:
+          description: |-
+            jenkins-centos7-static-agent
+          id: jenkins-centos7-static-agent
+          privateKeySource:
+            directEntry:
+              privateKey: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: jenkins
+      - basicSSHUserPrivateKey:
+          description: |-
+            windows2012
+          id: windows2012
+          privateKeySource:
+            directEntry:
+              privateKey: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman
+      - basicSSHUserPrivateKey:
+          description: |-
+            github-sshkey-misterman1
+          id: github-sshkey-misterman1
+          privateKeySource:
+            directEntry:
+              privateKey: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman1
+      - usernamePassword:
+          description: |-
+            misterman1-githubaccount-accesstoken-api
+          id: misterman1-githubaccount-accesstoken-api
+          password: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman1
+      - string:
+          description: |-
+            Webhook secret for https://github.com/apps/cloudbees-ci-misterman1-casc
+          id: 00428b3c-7e38-4fcd-a520-ddaaa2bd4c17
+          scope: SYSTEM
+          secret: '{AQAAABAAAAblablabla}'
+      - string:
+          description: |-
+            Webhook secret for https://github.com/apps/cloudbees-ci-misterman1-practice
+          id: 11dc6f8e-d68a-4fde-93de-d264a0c019a9
+          scope: SYSTEM
+          secret: '{AQAAABAAAAblablabla}'
+      - string:
+          description: |-
+            gh_pat_secrettest
+          id: gh_pat_secrettest
+          scope: GLOBAL
+          secret: '{AQAAABAAAAblablabla}'
+      - string:
+          description: |-
+            mistermanbb
+          id: mistermanbb
+          scope: GLOBAL
+          secret: '{AQAAABAAAAblablabla}'
+      - usernamePassword:
+          description: |-
+            bbactoken
+          id: bbactoken
+          password: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman@cloudbees.com
+      - string:
+          description: |-
+            jmrepokey
+          id: jmrepokey
+          scope: GLOBAL
+          secret: '{AQAAABAAAAblablabla}'
+      - usernamePassword:
+          description: |-
+            cloudbees-api-token
+          id: cloudbees-api-token
+          password: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman
+      - string:
+          description: |-
+            zach_ken_admin
+          id: zach_ken_admin
+          scope: GLOBAL
+          secret: '{AQAAABAAAAblablabla}'
+      - file:
+          description: |-
+            values-dev-deleteme
+          fileName: values-dev.yaml
+          id: values-dev-deleteme
+          scope: GLOBAL
+          secretBytes: '{AQAAABAAAAblablabla}'
+      - basicSSHUserPrivateKey:
+          description: |-
+            jenkins-centos7-static-agent
+          id: a1jenkins-centos7-static-agent
+          privateKeySource:
+            directEntry:
+              privateKey: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: jenkins
+      - basicSSHUserPrivateKey:
+          description: |-
+            windows2012
+          id: a1windows2012
+          privateKeySource:
+            directEntry:
+              privateKey: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman
+      - basicSSHUserPrivateKey:
+          description: |-
+            github-sshkey-misterman1
+          id: a1github-sshkey-misterman1
+          privateKeySource:
+            directEntry:
+              privateKey: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman1
+      - usernamePassword:
+          description: |-
+            misterman1-githubaccount-accesstoken-api
+          id: a1misterman1-githubaccount-accesstoken-api
+          password: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman1
+      - string:
+          description: |-
+            Webhook secret for https://github.com/apps/cloudbees-ci-misterman1-casc
+          id: a100428b3c-7e38-4fcd-a520-ddaaa2bd4c17
+          scope: SYSTEM
+          secret: '{AQAAABAAAAblablabla}'
+      - string:
+          description: |-
+            Webhook secret for https://github.com/apps/cloudbees-ci-misterman1-practice
+          id: a111dc6f8e-d68a-4fde-93de-d264a0c019a9
+          scope: SYSTEM
+          secret: '{AQAAABAAAAblablabla}'
+      - string:
+          description: |-
+            gh_pat_secrettest
+          id: a1gh_pat_secrettest
+          scope: GLOBAL
+          secret: '{AQAAABAAAAblablabla}'
+      - string:
+          description: |-
+            mistermanbb
+          id: a1mistermanbb
+          scope: GLOBAL
+          secret: '{AQAAABAAAAblablabla}'
+      - usernamePassword:
+          description: |-
+            bbactoken
+          id: a1bbactoken
+          password: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman@cloudbees.com
+      - string:
+          description: |-
+            jmrepokey
+          id: a1jmrepokey
+          scope: GLOBAL
+          secret: '{AQAAABAAAAblablabla}'
+      - usernamePassword:
+          description: |-
+            cloudbees-api-token
+          id: a1cloudbees-api-token
+          password: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman
+      - string:
+          description: |-
+            zach_ken_admin
+          id: a1zach_ken_admin
+          scope: GLOBAL
+          secret: '{AQAAABAAAAblablabla}'
+      - file:
+          description: |-
+            values-dev-deleteme
+          fileName: values-dev.yaml
+          id: a1values-dev-deleteme
+          scope: GLOBAL
+          secretBytes: '{AQAAABAAAAblablabla}'
+      - basicSSHUserPrivateKey:
+          description: |-
+            jenkins-centos7-static-agent
+          id: a2jenkins-centos7-static-agent
+          privateKeySource:
+            directEntry:
+              privateKey: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: jenkins
+      - basicSSHUserPrivateKey:
+          description: |-
+            windows2012
+          id: a2windows2012
+          privateKeySource:
+            directEntry:
+              privateKey: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman
+      - basicSSHUserPrivateKey:
+          description: |-
+            github-sshkey-misterman1
+          id: a2github-sshkey-misterman1
+          privateKeySource:
+            directEntry:
+              privateKey: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman1
+      - usernamePassword:
+          description: |-
+            misterman1-githubaccount-accesstoken-api
+          id: a2misterman1-githubaccount-accesstoken-api
+          password: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman1
+      - string:
+          description: |-
+            Webhook secret for https://github.com/apps/cloudbees-ci-misterman1-casc
+          id: a200428b3c-7e38-4fcd-a520-ddaaa2bd4c17
+          scope: SYSTEM
+          secret: '{AQAAABAAAAblablabla}'
+      - string:
+          description: |-
+            Webhook secret for https://github.com/apps/cloudbees-ci-misterman1-practice
+          id: a211dc6f8e-d68a-4fde-93de-d264a0c019a9
+          scope: SYSTEM
+          secret: '{AQAAABAAAAblablabla}'
+      - string:
+          description: |-
+            gh_pat_secrettest
+          id: a2gh_pat_secrettest
+          scope: GLOBAL
+          secret: '{AQAAABAAAAblablabla}'
+      - string:
+          description: |-
+            mistermanbb
+          id: a2mistermanbb
+          scope: GLOBAL
+          secret: '{AQAAABAAAAblablabla}'
+      - usernamePassword:
+          description: |-
+            bbactoken
+          id: a2bbactoken
+          password: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman@cloudbees.com
+      - string:
+          description: |-
+            jmrepokey
+          id: a2jmrepokey
+          scope: GLOBAL
+          secret: '{AQAAABAAAAblablabla}'
+      - usernamePassword:
+          description: |-
+            cloudbees-api-token
+          id: a2cloudbees-api-token
+          password: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman
+      - string:
+          description: |-
+            zach_ken_admin
+          id: a2zach_ken_admin
+          scope: GLOBAL
+          secret: '{AQAAABAAAAblablabla}'
+      - file:
+          description: |-
+            values-dev-deleteme
+          fileName: values-dev.yaml
+          id: a2values-dev-deleteme
+          scope: GLOBAL
+          secretBytes: '{AQAAABAAAAblablabla}'
+      - basicSSHUserPrivateKey:
+          description: |-
+            jenkins-centos7-static-agent
+          id: a3jenkins-centos7-static-agent
+          privateKeySource:
+            directEntry:
+              privateKey: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: jenkins
+      - basicSSHUserPrivateKey:
+          description: |-
+            windows2012
+          id: a3windows2012
+          privateKeySource:
+            directEntry:
+              privateKey: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman
+      - basicSSHUserPrivateKey:
+          description: |-
+            github-sshkey-misterman1
+          id: a3github-sshkey-misterman1
+          privateKeySource:
+            directEntry:
+              privateKey: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman1
+      - usernamePassword:
+          description: |-
+            misterman1-githubaccount-accesstoken-api
+          id: a3misterman1-githubaccount-accesstoken-api
+          password: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman1
+      - string:
+          description: |-
+            Webhook secret for https://github.com/apps/cloudbees-ci-misterman1-casc
+          id: a300428b3c-7e38-4fcd-a520-ddaaa2bd4c17
+          scope: SYSTEM
+          secret: '{AQAAABAAAAblablabla}'
+      - string:
+          description: |-
+            Webhook secret for https://github.com/apps/cloudbees-ci-misterman1-practice
+          id: a311dc6f8e-d68a-4fde-93de-d264a0c019a9
+          scope: SYSTEM
+          secret: '{AQAAABAAAAblablabla}'
+      - string:
+          description: |-
+            gh_pat_secrettest
+          id: a3gh_pat_secrettest
+          scope: GLOBAL
+          secret: '{AQAAABAAAAblablabla}'
+      - string:
+          description: |-
+            mistermanbb
+          id: a3mistermanbb
+          scope: GLOBAL
+          secret: '{AQAAABAAAAblablabla}'
+      - usernamePassword:
+          description: |-
+            bbactoken
+          id: a3bbactoken
+          password: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman@cloudbees.com
+      - string:
+          description: |-
+            jmrepokey
+          id: a3jmrepokey
+          scope: GLOBAL
+          secret: '{AQAAABAAAAblablabla}'
+      - usernamePassword:
+          description: |-
+            cloudbees-api-token
+          id: a3cloudbees-api-token
+          password: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman
+      - string:
+          description: |-
+            zach_ken_admin
+          id: a3zach_ken_admin
+          scope: GLOBAL
+          secret: '{AQAAABAAAAblablabla}'
+      - file:
+          description: |-
+            values-dev-deleteme
+          fileName: values-dev.yaml
+          id: a3values-dev-deleteme
+          scope: GLOBAL
+          secretBytes: '{AQAAABAAAAblablabla}'
+      - basicSSHUserPrivateKey:
+          description: |-
+            jenkins-centos7-static-agent
+          id: a4jenkins-centos7-static-agent
+          privateKeySource:
+            directEntry:
+              privateKey: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: jenkins
+      - basicSSHUserPrivateKey:
+          description: |-
+            windows2012
+          id: a4windows2012
+          privateKeySource:
+            directEntry:
+              privateKey: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman
+      - basicSSHUserPrivateKey:
+          description: |-
+            github-sshkey-misterman1
+          id: a4github-sshkey-misterman1
+          privateKeySource:
+            directEntry:
+              privateKey: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman1
+      - usernamePassword:
+          description: |-
+            misterman1-githubaccount-accesstoken-api
+          id: a4misterman1-githubaccount-accesstoken-api
+          password: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman1
+      - string:
+          description: |-
+            Webhook secret for https://github.com/apps/cloudbees-ci-misterman1-casc
+          id: a400428b3c-7e38-4fcd-a520-ddaaa2bd4c17
+          scope: SYSTEM
+          secret: '{AQAAABAAAAblablabla}'
+      - string:
+          description: |-
+            Webhook secret for https://github.com/apps/cloudbees-ci-misterman1-practice
+          id: a411dc6f8e-d68a-4fde-93de-d264a0c019a9
+          scope: SYSTEM
+          secret: '{AQAAABAAAAblablabla}'
+      - string:
+          description: |-
+            gh_pat_secrettest
+          id: a4gh_pat_secrettest
+          scope: GLOBAL
+          secret: '{AQAAABAAAAblablabla}'
+      - string:
+          description: |-
+            mistermanbb
+          id: a4mistermanbb
+          scope: GLOBAL
+          secret: '{AQAAABAAAAblablabla}'
+      - usernamePassword:
+          description: |-
+            bbactoken
+          id: a4bbactoken
+          password: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman@cloudbees.com
+      - string:
+          description: |-
+            jmrepokey
+          id: a4jmrepokey
+          scope: GLOBAL
+          secret: '{AQAAABAAAAblablabla}'
+      - usernamePassword:
+          description: |-
+            cloudbees-api-token
+          id: a4cloudbees-api-token
+          password: '{AQAAABAAAAblablabla}'
+          scope: GLOBAL
+          username: misterman
+      - string:
+          description: |-
+            zach_ken_admin
+          id: a4zach_ken_admin
+          scope: GLOBAL
+          secret: '{AQAAABAAAAblablabla}'
+      - file:
+          description: |-
+            values-dev-deleteme
+          fileName: values-dev.yaml
+          id: a4values-dev-deleteme
+          scope: GLOBAL
+          secretBytes: '{AQAAABAAAAblablabla}'
 jenkins:
   clouds:
   - operationsCenterAgentProvisioningService


### PR DESCRIPTION
This pull request refactors the `traverse_credentials` function and related utilities in `bundleutils.py` to improve the handling of in-memory objects during JSON patch operations, reducing reliance on file I/O. It also introduces a new function for applying patches directly to files and updates the corresponding logic in other parts of the codebase.

### Refactoring of `traverse_credentials` and patch application:

* Updated `traverse_credentials` to work with an in-memory object (`fileobj`) alongside the filename, ensuring changes are applied to the object and returned. This reduces redundant file I/O operations. [[1]](diffhunk://#diff-b4f0dfdaa815891690cc3b4a6ab100ffef72fd03f3def7fc810355d9e16cc334R3415) [[2]](diffhunk://#diff-b4f0dfdaa815891690cc3b4a6ab100ffef72fd03f3def7fc810355d9e16cc334L3505-R3506) [[3]](diffhunk://#diff-b4f0dfdaa815891690cc3b4a6ab100ffef72fd03f3def7fc810355d9e16cc334L3514-R3521) [[4]](diffhunk://#diff-b4f0dfdaa815891690cc3b4a6ab100ffef72fd03f3def7fc810355d9e16cc334L3531-R3537) [[5]](diffhunk://#diff-b4f0dfdaa815891690cc3b4a6ab100ffef72fd03f3def7fc810355d9e16cc334L3556-R3560)
* Introduced `apply_patch_obj`, a new function for applying patches to an in-memory object, replacing the previous `apply_patch` function.
* Added `apply_patch_file` to handle file-based patching, encapsulating the logic for loading, patching, and saving files.
* Updated `handle_patches` to use the new `apply_patch_file` function for applying patches to files.

### Improvements to `apply_replacements`:

* Modified `apply_replacements` to use the in-memory `fileobj` for processing replacements and save the updated object back to the file. This aligns with the refactored approach in `traverse_credentials`.

### Minor cleanup:

* Removed an unnecessary blank line in a YAML test resource file.